### PR TITLE
Fix edit_club admin view

### DIFF
--- a/tournamentcontrol/competition/admin.py
+++ b/tournamentcontrol/competition/admin.py
@@ -352,10 +352,6 @@ class CompetitionAdminComponent(AdminComponent):
                     url(r'officials/(?P<season_id>\d+)/$', self.officials, name='officials'),
                     url(r'(?P<season_id>\d+)/registration.(?P<mode>html|pdf)$', self.registration_form, name='registration-form'),
 
-                    url(r'^person/', include([
-                        url(r'^add/$', self.edit_person, name='add'),
-                    ], namespace='person')),
-
                     # FIXME should have a 'season' namespace
                     url(r'^(?P<season_id>\d+)/team/(?P<team_id>\d+)/', include([
                         url(r'^$', self.edit_team_members, name='edit'),

--- a/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/club/team.inc.html
+++ b/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/club/team.inc.html
@@ -26,4 +26,6 @@
 	</td>
 {% endblock table-columns %}
 
+{% block table-row-empty %}{% endblock %}
+
 {% block empty-row-colspan %}5{% endblock %}

--- a/tournamentcontrol/competition/tests/test_competition_admin.py
+++ b/tournamentcontrol/competition/tests/test_competition_admin.py
@@ -182,7 +182,6 @@ class GoodViewTests(TestCase):
         pool = factories.StageGroupFactory.create()
         self.assertGoodNamespace(pool)
 
-    @unittest.skip("Should not be, but is, failing.")
     def test_club(self):
         club = factories.ClubFactory.create()
         self.assertLoginRequired('admin:fixja:club:list')


### PR DESCRIPTION
It's not possible to directly create a Team from the Club context, this should
be done from the Division context. It is possible to edit Team from here
though.

Resolves #20.