### PR TITLE
Fix the draw generation related matches bug

### DIFF
--- a/tests/vitriolic/settings.py
+++ b/tests/vitriolic/settings.py
@@ -185,3 +185,17 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.10/howto/static-files/
 
 STATIC_URL = '/static/'
+
+
+# Logging setup. Adjust handlers as required.
+
+LOGGING = {
+    "version": 1,
+    "handlers": {
+        "console": {"class": "logging.StreamHandler"},
+        "null": {"class": "logging.NullHandler"},
+    },
+    "loggers": {
+        "": {"level": "DEBUG", "handlers": ["null"]},
+    },
+}

--- a/tournamentcontrol/competition/forms.py
+++ b/tournamentcontrol/competition/forms.py
@@ -982,6 +982,12 @@ class DrawGenerationMatchFormSet(BaseDrawGenerationMatchFormSet):
     def save(self, *args, **kwargs):
         matches = []
         for form in self.forms:
+            if form.instance.home_team_eval_related is not None:
+                form.instance.home_team_eval_related = Match.objects.get(
+                    uuid=form.instance.home_team_eval_related.uuid)
+            if form.instance.away_team_eval_related is not None:
+                form.instance.away_team_eval_related = Match.objects.get(
+                    uuid=form.instance.away_team_eval_related.uuid)
             matches.append(form.save())
         return matches
 

--- a/tournamentcontrol/competition/models.py
+++ b/tournamentcontrol/competition/models.py
@@ -1594,7 +1594,7 @@ class Match(AdminUrlMixin, RankImportanceMixin, models.Model):
         return self.title
 
     def __repr__(self):
-        return '<Match: %s: %s vs %s>' % (self.round, self.home_team, self.away_team)
+        return '<Match: %s: %s>' % (self.round, self)
 
 
 class LadderBase(models.Model):

--- a/tournamentcontrol/competition/tests/test_formsets.py
+++ b/tournamentcontrol/competition/tests/test_formsets.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
+import six
 from test_plus import TestCase
-
 from touchtechnology.common.tests.factories import UserFactory
 from tournamentcontrol.competition.models import Match
 from tournamentcontrol.competition.tests import factories
@@ -195,21 +195,13 @@ class DrawGenerationMatchFormSetTest(TestCase):
                 data=data1)
             self.response_302()
 
-        self.assertEqual(Match.objects.count(), 4)
-
-        SF1, SF2 = stage.matches.filter(round=1)
-        self.assertItemsEqual(
-            Match.objects.values_list(
-                'label',
-                'home_team_eval',
-                'home_team_eval_related',
-                'away_team_eval',
-                'away_team_eval_related',
-            ),
+        six.assertCountEqual(
+            self,
+            [(m.get_home_team(), m.get_away_team()) for m in Match.objects.all()],
             [
-                ('Semi Final 1', 'P1', None, 'P4', None),
-                ('Semi Final 2', 'P2', None, 'P3', None),
-                ('Bronze Medal', 'L', SF1.pk, 'L', SF2.pk),
-                ('Gold Medal', 'W', SF1.pk, 'W', SF2.pk),
+                ({'title': '1st  '}, {'title': '4th  '}),
+                ({'title': '2nd  '}, {'title': '3rd  '}),
+                ({'title': 'Loser Semi Final 1'}, {'title': 'Loser Semi Final 2'}),
+                ({'title': 'Winner Semi Final 1'}, {'title': 'Winner Semi Final 2'}),
             ],
         )


### PR DESCRIPTION
The `home_team_eval_related` and `away_team_eval_related` attributes on a match that is related to another match will not have the primary key of that match because it is not yet saved in the database.

We have a UUID which is created upon instantiation, so use that to query the database for the correct match.