### PR TITLE
Fix TimeZoneChoiceField

### DIFF
--- a/tournamentcontrol/competition/constants.py
+++ b/tournamentcontrol/competition/constants.py
@@ -38,5 +38,5 @@ PYTZ_TIME_ZONE_CHOICES = [('\x20Standard', (('UTC', 'UTC'), ('GMT', 'GMT')))]
 for iso, name in pytz.country_names.items():
     values = sorted(pytz.country_timezones.get(iso, []))
     names = [s.rsplit("/", 1)[1].replace("_", " ") for s in values]
-    PYTZ_TIME_ZONE_CHOICES.append((name, zip(values, names)))
+    PYTZ_TIME_ZONE_CHOICES.append((name, [each for each in zip(values, names)]))
 PYTZ_TIME_ZONE_CHOICES.sort()


### PR DESCRIPTION
During Python 3 conversion this must have been missed.

Fixes #34.