### PR TITLE
refactor: move youtube thumbnail to async

### DIFF
--- a/tournamentcontrol/competition/admin.py
+++ b/tournamentcontrol/competition/admin.py
@@ -98,6 +98,7 @@ from tournamentcontrol.competition.sites import CompetitionAdminMixin
 from tournamentcontrol.competition.tasks import (
     generate_pdf_grid,
     generate_pdf_scorecards,
+    set_youtube_thumbnail,
 )
 from tournamentcontrol.competition.utils import (
     generate_fixture_grid,
@@ -1589,10 +1590,7 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
                             .update(part="snippet,status,contentDetails", body=body)
                             .execute()
                         )
-                        season.youtube.thumbnails().set(
-                            videoId=obj.external_identifier,
-                            media_body=obj.live_stream_thumbnail_media_body,
-                        ).execute()
+                        set_youtube_thumbnail.delay(obj.pk)
                         log.info("YouTube video %(id)r updated", broadcast)
 
                 # If we have enabled live-streaming, but don't have an external id, we
@@ -1608,10 +1606,7 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
                         .execute()
                     )
                     obj.external_identifier = broadcast["id"]
-                    season.youtube.thumbnails().set(
-                        videoId=obj.external_identifier,
-                        media_body=obj.live_stream_thumbnail_media_body,
-                    ).execute()
+                    set_youtube_thumbnail.delay(obj.pk)
                     video_link = f"https://youtu.be/{obj.external_identifier}"
                     obj.videos = (
                         [video_link]

--- a/tournamentcontrol/competition/models.py
+++ b/tournamentcontrol/competition/models.py
@@ -629,20 +629,6 @@ class Season(AdminUrlMixin, RankImportanceMixin, OrderedSitemapNode):
         )
 
     @cached_property
-    def live_stream_thumbnail_media_body(self):
-        try:
-            res = requests.get(self.live_stream_thumbnail)
-            res.raise_for_status()
-        except HTTPError:
-            return None
-        media = MediaInMemoryUpload(
-            res.content,
-            mimetype=res.headers["Content-Type"],
-            resumable=True,
-        )
-        return media
-
-    @cached_property
     def youtube(self):
         return build(
             "youtube",
@@ -1689,22 +1675,6 @@ class Match(AdminUrlMixin, RankImportanceMixin, models.Model):
     live_stream_thumbnail = models.URLField(blank=True, null=True)
 
     objects = MatchManager()
-
-    @cached_property
-    def live_stream_thumbnail_media_body(self):
-        if not self.live_stream_thumbnail:
-            return self.stage.division.season.live_stream_thumbnail_media_body
-        try:
-            res = requests.get(self.live_stream_thumbnail)
-            res.raise_for_status()
-        except HTTPError:
-            return None
-        media = MediaInMemoryUpload(
-            res.content,
-            mimetype=res.headers["Content-Type"],
-            resumable=True,
-        )
-        return media
 
     class Meta:
         get_latest_by = "datetime"

--- a/tournamentcontrol/competition/tasks.py
+++ b/tournamentcontrol/competition/tasks.py
@@ -1,6 +1,8 @@
 import base64
 
+import requests
 from celery import shared_task
+from googleapiclient.http import MediaInMemoryUpload
 
 from tournamentcontrol.competition.models import Match, Stage
 from tournamentcontrol.competition.utils import (
@@ -38,3 +40,27 @@ def generate_pdf_grid(season, extra_context, date=None):
     # We can't JSON encode bytes, so we need to base64 encode the
     # PDF document before handing it back to the result backend.
     return base64.b64encode(data).decode("utf8")
+
+
+@shared_task
+def set_youtube_thumbnail(match_pk):
+    """
+    Asynchronously use the Google YouTube Data API to set the thumbnail for
+    the match specified.
+    """
+    obj = Match.objects.get(pk=match_pk)
+    season = obj.stage.division.season
+
+    img = requests.get(obj.live_stream_thumbnail or season.live_stream_thumbnail)
+    img.raise_for_status()
+
+    media_body = MediaInMemoryUpload(
+        img.content,
+        mimetype=img.headers["Content-Type"],
+        resumable=True,
+    )
+
+    obj.stage.division.season.youtube.thumbnails().set(
+        videoId=obj.external_identifier,
+        media_body=media_body,
+    ).execute()


### PR DESCRIPTION
Have seen some timing out, so I am moving this to be run by celery in the background.

Refs #58.
