### PR TITLE
hackfix: default Match.eval to not run in lazy mode

### DIFF
--- a/tournamentcontrol/competition/models.py
+++ b/tournamentcontrol/competition/models.py
@@ -1920,7 +1920,7 @@ class Match(AdminUrlMixin, RankImportanceMixin, models.Model):
     winner = property(lambda self: self._winner_loser("W"))
     loser = property(lambda self: self._winner_loser("L"))
 
-    def eval(self, lazy=True):
+    def eval(self, lazy=False):
         """
         Attempt to populate the `home_team` and `away_team` fields as
         appropriate.


### PR DESCRIPTION
It has been a long time since I've worked on this code, but it isn't working now and I don't have time to write test cases.

Making a hackfix release so I can update the Federation of International Touch site for a currently running tournament.