### PR TITLE
perf: reduce query count of `CompetitionAdminComponent.match_schedule` view

### DIFF
--- a/tournamentcontrol/competition/admin.py
+++ b/tournamentcontrol/competition/admin.py
@@ -1815,6 +1815,11 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
         )
 
         dates = matches.dates("date", "day")
+
+        if not dates:
+            messages.error(request, _("No matches are available for rescheduling."))
+            return self.redirect(season.urls["edit"])
+
         redirect_to = season.urls["edit"]
 
         if request.method == "POST":

--- a/tournamentcontrol/competition/admin.py
+++ b/tournamentcontrol/competition/admin.py
@@ -1900,7 +1900,10 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
             request,
             queryset,
             formset_class=MatchScheduleFormSet,
-            formset_kwargs={"places": places},
+            formset_kwargs={
+                "places": places,
+                "timeslots": season.get_timeslots(date),
+            },
             post_save_redirect=self.redirect(season.urls["edit"]),
             templates=self.template_path("match/schedule.html"),
             extra_context=extra_context,

--- a/tournamentcontrol/competition/draw.py
+++ b/tournamentcontrol/competition/draw.py
@@ -371,7 +371,7 @@ class MatchCollection(object):
         return len(self.iterable)
 
     def __repr__(self):
-        return repr(self.iterable)
+        return f"<MatchCollection: {self.iterable!r}>"
 
     def add(self, match_id, match):
         self.keyed.setdefault(match_id, []).append(match)

--- a/tournamentcontrol/competition/forms.py
+++ b/tournamentcontrol/competition/forms.py
@@ -810,7 +810,7 @@ class DrawFormatForm(BootstrapFormControlMixin, ModelForm):
 
 
 class BaseMatchFormMixin(BootstrapFormControlMixin):
-    def __init__(self, timeslots, *args, **kwargs):
+    def __init__(self, timeslots=None, *args, **kwargs):
         super(BaseMatchFormMixin, self).__init__(*args, **kwargs)
 
         # set the queryset of the `home_team` and `away_team` fields

--- a/tournamentcontrol/competition/forms.py
+++ b/tournamentcontrol/competition/forms.py
@@ -810,7 +810,7 @@ class DrawFormatForm(BootstrapFormControlMixin, ModelForm):
 
 
 class BaseMatchFormMixin(BootstrapFormControlMixin):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, timeslots, *args, **kwargs):
         super(BaseMatchFormMixin, self).__init__(*args, **kwargs)
 
         # set the queryset of the `home_team` and `away_team` fields
@@ -829,11 +829,7 @@ class BaseMatchFormMixin(BootstrapFormControlMixin):
 
         # If the season has timeslot rules, substitute the default SelectTime
         # field for a drop-down list of timeslots.
-        if self.instance.stage.division.season.timeslots.exists():
-            timeslots = self.instance.stage.division.season.get_timeslots(
-                self.instance.date
-            )
-
+        if timeslots:
             if self.instance.home_team and self.instance.home_team.timeslots_after:
                 timeslots = [
                     timeslot
@@ -1262,13 +1258,16 @@ class MatchScheduleForm(BaseMatchFormMixin, ModelForm):
         self.ignore_clashes = ignore_clashes
 
         tzinfo = timezone.get_current_timezone()
-        __, tzname = timezone_choice(tzinfo.zone)
+        __, tzname = timezone_choice(str(tzinfo))
 
         def label_from_instance(obj):
-            try:
-                label = f"{'-' * 3} {obj.ground.title}"
-            except ObjectDoesNotExist:
-                label = obj.venue.title
+            if isinstance(obj, Venue):
+                label = obj.title
+            elif isinstance(obj, Ground):
+                label = f"{'-' * 3} {obj.title}"
+            else:
+                label = f"{obj}"
+
             if settings.USE_TZ:
                 __, tz = timezone_choice(obj.timezone)
                 if tz != tzname:
@@ -1358,9 +1357,10 @@ BaseMatchScheduleFormSet = modelformset_factory(Match, extra=0, form=MatchSchedu
 
 
 class MatchScheduleFormSet(BaseMatchScheduleFormSet):
-    def __init__(self, places, *args, **kwargs):
+    def __init__(self, places, timeslots, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.places = places
+        self.timeslots = timeslots
 
     def _management_form(self):
         """
@@ -1402,7 +1402,11 @@ class MatchScheduleFormSet(BaseMatchScheduleFormSet):
         ignore_clashes = bool(mfcd.get("ignore_clashes", False))
         # construct the form with our additional keyword arguments
         return super(MatchScheduleFormSet, self)._construct_form(
-            i, ignore_clashes=ignore_clashes, places=self.places, **kwargs
+            i,
+            ignore_clashes=ignore_clashes,
+            places=self.places,
+            timeslots=self.timeslots,
+            **kwargs,
         )
 
     def clean(self):

--- a/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/season/edit.html
+++ b/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/season/edit.html
@@ -52,10 +52,27 @@
 										<i class="fa fa-clock-o fa-fw"></i>
 										<span class="hidden-sm hidden-xs">&nbsp;{% trans "Run Sheet" %}</span>
 									</a>
-									<a href="{% url 'admin:fixja:match-grid' object.competition.pk object.pk date|date:"Ymd" "pdf" %}" class="btn btn-default btn-sm" role="button">
+									<div class="btn-group">
+										<button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
 										<i class="fa fa-table fa-fw"></i>
 										<span class="hidden-sm hidden-xs">&nbsp;{% trans "Matrix" %}</span>
-									</a>
+											<span class="caret"></span>
+										</button>
+										<ul class="dropdown-menu dropdown-menu-right" role="menu">
+											<li role="presentation">
+												<a href="{% url 'admin:fixja:match-grid' object.competition.pk object.pk date|date:"Ymd" "html" %}" role="button">
+													<i class="fa fa-html5 fa-fw"></i>
+													<span class="hidden-sm hidden-xs">&nbsp;{% trans "HTML" %}</span>
+												</a>
+											</li>
+											<li role="presentation">
+												<a href="{% url 'admin:fixja:match-grid' object.competition.pk object.pk date|date:"Ymd" "pdf" %}" role="button">
+													<i class="fa fa-file-pdf-o fa-fw"></i>
+													<span class="hidden-sm hidden-xs">&nbsp;{% trans "PDF" %}</span>
+												</a>
+											</li>
+										</ul>
+									</div>
 									<a href="{% url 'admin:competition:match-washout' object.competition.pk object.pk date|date:"Ymd" %}" class="btn btn-default btn-sm" role="button">
 										<i class="fa fa-umbrella fa-fw"></i>
 										<span class="hidden-sm hidden-xs">&nbsp;{% trans "Washout" %}</span>


### PR DESCRIPTION
- pass the timeslots to the formset constructor to feed into each form constructor
- remove the `.ground` lookup in the `label_from_instance` function in `MatchScheduleForm`
