### PR TITLE
feature: add the place in the match serializer

### DIFF
--- a/tournamentcontrol/competition/migrations/0037_alter_match_evaluated.py
+++ b/tournamentcontrol/competition/migrations/0037_alter_match_evaluated.py
@@ -1,4 +1,3 @@
-
 from django.db import migrations, models
 
 

--- a/tournamentcontrol/competition/migrations/0038_match_live_stream.py
+++ b/tournamentcontrol/competition/migrations/0038_match_live_stream.py
@@ -1,4 +1,3 @@
-
 from django.db import migrations
 
 import touchtechnology.common.db.models

--- a/tournamentcontrol/competition/migrations/0039_season_live_stream.py
+++ b/tournamentcontrol/competition/migrations/0039_season_live_stream.py
@@ -1,4 +1,3 @@
-
 from django.db import migrations
 
 import touchtechnology.common.db.models

--- a/tournamentcontrol/competition/migrations/0040_season_live_stream_privacy.py
+++ b/tournamentcontrol/competition/migrations/0040_season_live_stream_privacy.py
@@ -1,4 +1,3 @@
-
 from django.db import migrations, models
 
 

--- a/tournamentcontrol/competition/migrations/0041_ground_live_stream.py
+++ b/tournamentcontrol/competition/migrations/0041_ground_live_stream.py
@@ -1,4 +1,3 @@
-
 from django.db import migrations
 
 import touchtechnology.common.db.models

--- a/tournamentcontrol/competition/migrations/0042_ground_external_identifier.py
+++ b/tournamentcontrol/competition/migrations/0042_ground_external_identifier.py
@@ -1,4 +1,3 @@
-
 from django.db import migrations, models
 
 

--- a/tournamentcontrol/competition/migrations/0043_alter_ground_external_identifier.py
+++ b/tournamentcontrol/competition/migrations/0043_alter_ground_external_identifier.py
@@ -1,4 +1,3 @@
-
 from django.db import migrations, models
 
 

--- a/tournamentcontrol/competition/migrations/0044_match_live_stream_bind.py
+++ b/tournamentcontrol/competition/migrations/0044_match_live_stream_bind.py
@@ -1,4 +1,3 @@
-
 from django.db import migrations, models
 
 

--- a/tournamentcontrol/competition/migrations/0045_ground_stream_key.py
+++ b/tournamentcontrol/competition/migrations/0045_ground_stream_key.py
@@ -1,4 +1,3 @@
-
 from django.db import migrations, models
 
 

--- a/tournamentcontrol/competition/migrations/0046_alter_match_live_stream_bind.py
+++ b/tournamentcontrol/competition/migrations/0046_alter_match_live_stream_bind.py
@@ -1,4 +1,3 @@
-
 from django.db import migrations, models
 
 

--- a/tournamentcontrol/competition/migrations/0047_season_live_stream_oauth2.py
+++ b/tournamentcontrol/competition/migrations/0047_season_live_stream_oauth2.py
@@ -1,4 +1,3 @@
-
 import django.contrib.postgres.fields
 from django.db import migrations, models
 

--- a/tournamentcontrol/competition/migrations/0048_season_live_stream_thumbnail.py
+++ b/tournamentcontrol/competition/migrations/0048_season_live_stream_thumbnail.py
@@ -1,4 +1,3 @@
-
 from django.db import migrations, models
 
 

--- a/tournamentcontrol/competition/migrations/0049_match_live_stream_thumbnail.py
+++ b/tournamentcontrol/competition/migrations/0049_match_live_stream_thumbnail.py
@@ -1,4 +1,3 @@
-
 from django.db import migrations, models
 
 

--- a/tournamentcontrol/competition/rest/v1/division.py
+++ b/tournamentcontrol/competition/rest/v1/division.py
@@ -4,6 +4,7 @@ from rest_framework_nested.serializers import NestedHyperlinkedModelSerializer
 from tournamentcontrol.competition import models
 
 from .club import ClubSerializer
+from .season import PlaceSerializer
 from .viewsets import SlugViewSet
 
 
@@ -11,6 +12,7 @@ class ListMatchSerializer(serializers.ModelSerializer):
     round = serializers.SerializerMethodField(read_only=True)
     home_team = serializers.SerializerMethodField(read_only=True)
     away_team = serializers.SerializerMethodField(read_only=True)
+    play_at = PlaceSerializer(read_only=True)
 
     class Meta:
         model = models.Match
@@ -29,6 +31,7 @@ class ListMatchSerializer(serializers.ModelSerializer):
             "away_team_score",
             "referees",
             "videos",
+            "play_at",
         )
 
     def get_round(self, obj):

--- a/tournamentcontrol/competition/rest/v1/season.py
+++ b/tournamentcontrol/competition/rest/v1/season.py
@@ -6,6 +6,12 @@ from tournamentcontrol.competition import models
 from .viewsets import SlugViewSet
 
 
+class PlaceSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.Place
+        fields = ("id", "title", "abbreviation", "timezone")
+
+
 class RefereeClubSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Club


### PR DESCRIPTION
Resolves an oversight which meant that the place that a match is scheduled to take place is not exposed in the REST API.
