### PR TITLE
Update dependency groups in configuration files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,12 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[project.optional-dependencies]
+[dependency-groups]
 dj42 = ["Django~=4.2.0"]
 dj52 = ["Django~=5.2.0"]
-
-[dependency-groups]
 test = ["coverage", "django-environ", "django-test-plus", "factory_boy", "freezegun", "tblib"]
+
+[project.optional-dependencies]
 redis = ["django-redis-cache", "redis"]
 admin = ["django-bootstrap3", "django-gravatar2"]
 common = []

--- a/tox.ini
+++ b/tox.ini
@@ -9,15 +9,15 @@ requires =
 
 [testenv]
 package = uv-editable
-extras =
+dependency_groups =
     dj42: dj42
     dj52: dj52
-dependency_groups =
+    test
+extras =
     admin
     competition
     content
     news
-    test
 changedir = tests
 commands =
     coverage run manage.py test --debug-sql --timing {posargs:touchtechnology.common touchtechnology.admin touchtechnology.content touchtechnology.news tournamentcontrol.competition}


### PR DESCRIPTION
Revise the dependency structure in `pyproject.toml` and `tox.ini` to align with the latest specifications for dependency groups, enhancing clarity and organization.

See https://packaging.python.org/en/latest/specifications/dependency-groups/

> This specification defines Dependency Groups, a mechanism for storing package requirements in `pyproject.toml` files such that they are not included in project metadata when it is built.
>
> Dependency Groups are suitable for internal development use-cases like linting and testing, as well as for projects which are not built for distribution, like collections of related scripts.

We don't need to share our testing dependencies in the packages we produce, but we do need to expose the extras.