### PR TITLE
Fix `ValueError` when trying to add a `StageGroup`

### DIFF
--- a/touchtechnology/admin/static/select2/select2.css
+++ b/touchtechnology/admin/static/select2/select2.css
@@ -11,6 +11,10 @@ Version: 3.5.2 Timestamp: Sat Nov  1 14:43:36 EDT 2014
     vertical-align: middle;
 }
 
+.select_multiple .select2-container {
+    width: 100%;
+}
+
 .select2-container,
 .select2-drop,
 .select2-search,

--- a/tournamentcontrol/competition/tests/test_competition_admin.py
+++ b/tournamentcontrol/competition/tests/test_competition_admin.py
@@ -1079,3 +1079,13 @@ class BackendTests(TestCase):
             data=data,
         )
         self.response_302()
+
+    def test_bug_100_add_stagegroup(self):
+        """
+        Adding a Pool (StageGroup) should not fail to render.
+        """
+        stage = factories.StageFactory.create()
+        self.get_check_200(
+            stage._get_admin_namespace() + ":stagegroup:add",
+            *stage._get_url_args(),
+        )


### PR DESCRIPTION
Update the `StageGroupForm` logic to ensure the initial queryset and team selection are handled correctly, preventing a `ValueError` when accessing related objects on an unsaved `StageGroup` instance. Add a test to verify that adding a pool does not fail to render.

Fixes #100