### PR TITLE
feat: improve referee appointment handling

### DIFF
--- a/touchtechnology/admin/mixins.py
+++ b/touchtechnology/admin/mixins.py
@@ -14,13 +14,23 @@ class AdminUrlMixin(object):
     def _get_url_args(self):
         raise NotImplementedError
 
+    def _get_url_names(self):
+        # Default view names - extend on your model to add extra views
+        return ["edit", "delete", "perms"]
+
     @cached_property
     def urls(self):
+        return {
+            view: reverse_lazy(lookup["url_name"], args=lookup["args"])
+            for view, lookup in self.url_names.items()
+        }
+
+    @cached_property
+    def url_names(self) -> dict[str, dict[str, tuple]]:
         namespace = self._get_admin_namespace()
         args = self._get_url_args()
         crud = {
-            "edit": reverse_lazy("%s:edit" % namespace, args=args),
-            "delete": reverse_lazy("%s:delete" % namespace, args=args),
-            "perms": reverse_lazy("%s:perms" % namespace, args=args),
+            name: {"url_name": f"{namespace}:{name}", "args": args}
+            for name in self._get_url_names()
         }
         return crud

--- a/touchtechnology/content/middleware.py
+++ b/touchtechnology/content/middleware.py
@@ -246,12 +246,10 @@ class SitemapNodeMiddleware(MiddlewareMixin):
 
 def redirect_middleware(get_response):
     def middleware(request):
-        try:
-            obj = Redirect.objects.get(source_url__exact=request.path)
-        except ObjectDoesNotExist:
-            response = get_response(request)
-        else:
-            response = redirect(obj.destination_url, obj.permanent)
-        return response
+        objects = Redirect.objects.filter(source_url__exact=request.path)
+        if objects.exists():
+            instance = objects.first()
+            return redirect(instance.destination_url, instance.permanent)
+        return get_response(request)
 
     return middleware

--- a/tournamentcontrol/competition/models.py
+++ b/tournamentcontrol/competition/models.py
@@ -203,7 +203,7 @@ class Club(AdminUrlMixin, SitemapNodeBase):
     twitter = TwitterField(
         max_length=50,
         blank=True,
-        help_text=_("Official Twitter name for use in " 'social "mentions"'),
+        help_text=_('Official Twitter name for use in social "mentions"'),
     )
     facebook = models.URLField(max_length=255, blank=True)
     youtube = models.URLField(max_length=255, blank=True)
@@ -214,19 +214,19 @@ class Club(AdminUrlMixin, SitemapNodeBase):
         related_name="+",
         verbose_name=_("Primary contact"),
         label_from_instance="get_full_name",
-        help_text=_("Appears on the front-end with other " "club information."),
+        help_text=_("Appears on the front-end with other club information."),
         on_delete=PROTECT,
     )
     primary_position = models.CharField(
         max_length=200,
         blank=True,
         verbose_name=_("Position"),
-        help_text=_("Position of the primary " "contact"),
+        help_text=_("Position of the primary contact"),
     )
     abbreviation = models.CharField(
         max_length=3,
         blank=True,
-        help_text=_("Optional 3-letter " "abbreviation to be used on " "scoreboards."),
+        help_text=_("Optional 3-letter abbreviation to be used on scoreboards."),
     )
 
     class Meta:
@@ -284,9 +284,7 @@ class Club(AdminUrlMixin, SitemapNodeBase):
             ORDER BY
                 "competition_person"."last_name" ASC,
                 "competition_person"."first_name" ASC
-        """ % {
-            "user": get_user_model()._meta.db_table
-        }
+        """ % {"user": get_user_model()._meta.db_table}
         params = {
             "club": self.pk,
         }
@@ -483,7 +481,7 @@ class Season(AdminUrlMixin, RankImportanceMixin, OrderedSitemapNode):
         validators=[validate_hashtag],
         verbose_name="Hash Tag",
         help_text=mark_safe(
-            _("Your official <em>hash tag</em> " "for social media promotions.")
+            _("Your official <em>hash tag</em> for social media promotions.")
         ),
     )
     enabled = BooleanField(default=True)
@@ -1148,7 +1146,7 @@ class Team(AdminUrlMixin, RankDivisionMixin, OrderedSitemapNode):
         verbose_name=_("Don't clash"),
         label_from_instance=team_and_division,
         symmetrical=True,
-        help_text=_("Select any teams that must " "not play at the same time."),
+        help_text=_("Select any teams that must not play at the same time."),
     )
 
     class Meta:
@@ -1692,6 +1690,9 @@ class Match(AdminUrlMixin, RankImportanceMixin, models.Model):
             self.pk,
         )
 
+    def _get_url_names(self):
+        return super()._get_url_names() + ["referees"]
+
     def get_date(self, tzinfo):
         dt = self.get_datetime(tzinfo)
         if dt is not None:
@@ -1922,7 +1923,7 @@ class Match(AdminUrlMixin, RankImportanceMixin, models.Model):
             stage = self.stage.comes_after
         except Stage.DoesNotExist:
             logger.warning(
-                "Stage is first, %r should not be attempting to be " "evaluated.", self
+                "Stage is first, %r should not be attempting to be evaluated.", self
             )
             return (self.home_team, self.away_team)
 

--- a/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/match/list.inc.html
+++ b/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/match/list.inc.html
@@ -29,3 +29,13 @@
 {% endblock %}
 
 {% block empty-row-colspan %}7{% endblock %}
+
+{% block row-buttons-items %}
+<li role="presentation">
+	<a role="button" href="{{ obj.urls.referees }}">
+		<i class="fa fa-flag fa-fw"></i>
+		{% trans "Referees" %}
+	</a>
+</li>
+{{ block.super }}
+{% endblock row-buttons-items %}

--- a/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/match_detail.html
+++ b/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/match_detail.html
@@ -8,7 +8,9 @@
 	<div class="heading-block">
 		<h3>
 			{{ match.stage.division }}: {{ match }}
-			<span class="pull-right hidden-xs">{{ match.datetime|timezone:match.play_at.timezone|date:"l jS F Y, g:i a e" }}</span>
+			{% with tz=match.play_at.timezone|default:match.stage.division.season.timezone %}
+				<span class="pull-right hidden-xs">{{ match.datetime|timezone:tz|date:"l jS F Y, g:i a e" }}</span>
+			{% endwith %}
 		</h3>
 	</div>
 

--- a/tournamentcontrol/competition/tests/factories.py
+++ b/tournamentcontrol/competition/tests/factories.py
@@ -243,6 +243,15 @@ class TeamAssociationFactory(DjangoModelFactory):
     person = factory.SubFactory(PersonFactory)
 
 
+class SeasonRefereeFactory(DjangoModelFactory):
+    class Meta:
+        model = models.SeasonReferee
+
+    season = factory.SubFactory(SeasonFactory)
+    club = factory.SubFactory(ClubFactory)
+    person = factory.SubFactory(PersonFactory)
+
+
 class DrawFormatFactory(DjangoModelFactory):
     class Meta:
         model = models.DrawFormat


### PR DESCRIPTION
- Added `_get_url_names` method to `AdminUrlMixin` for better URL management.
- Refactored URL generation in `urls` property to utilize the new method.
- Updated match templates to include a link for referees appointments and fixed bug with timezone handling.
- Introduced `SeasonRefereeFactory` for testing referee appointments.
- Added tests for editing match referee appointments considering live streaming settings.

Closes #80 - because we have moved the referee field away from the `edit_match` view to it's own view.