### PR TITLE
`TypeError` when saving match schedule due to `ZoneInfo` usage

### DIFF
--- a/tournamentcontrol/competition/models.py
+++ b/tournamentcontrol/competition/models.py
@@ -1797,12 +1797,12 @@ class Match(AdminUrlMixin, RankImportanceMixin, models.Model):
             self.datetime = None
 
         if self.datetime is not None:
-            try:
-                tzinfo = ZoneInfo(self.play_at.timezone)
-            except (AttributeError, ZoneInfoNotFoundError):
-                tzinfo = timezone.get_default_timezone()
-            else:
-                self.datetime = timezone.make_aware(self.datetime, tzinfo)
+            tzinfo = (
+                self.play_at.timezone
+                if self.play_at is not None
+                else self.stage.division.season.timezone
+            )
+            self.datetime = timezone.make_aware(self.datetime, tzinfo)
 
     @cached_property
     def title(self):


### PR DESCRIPTION
This pull request includes changes to improve timezone handling in the `clean` method of the `Competition` model and to enhance the test coverage and functionality of the `test_season_summary` method in the competition admin tests.

### Improvements to timezone handling:

* [`tournamentcontrol/competition/models.py`](diffhunk://#diff-7d952f5acc74581a7758503a601e43379d6d1438ed1f198ae07c4003f54bc337L1800-R1804): Updated the `clean` method to use the timezone from `self.play_at` if available, or fall back to the timezone of the associated season's division. This simplifies the logic and ensures a valid timezone is always used.

### Enhancements to test coverage and functionality:

* [`tournamentcontrol/competition/tests/test_competition_admin.py`](diffhunk://#diff-6a3fc53b4be5051f51b6edbce5ca5a5160d1acb41ab99e33fac4e0514e72aeacL352-R378): Refactored the `test_season_summary` method to include the creation of a `Ground` and `Match` object, dynamically generate arguments for the test, and validate form submission with specific data. Added assertions to check the response content and ensure proper redirection after posting form data.

Fixes #111