### PR TITLE
Refactor draw wizard and admin URL management

### DIFF
--- a/touchtechnology/admin/mixins.py
+++ b/touchtechnology/admin/mixins.py
@@ -1,6 +1,14 @@
 from django.urls import reverse_lazy
 from django.utils.functional import cached_property
 
+from dataclasses import dataclass
+
+
+@dataclass
+class AdminUrlLookup:
+    url_name: str
+    args: tuple
+
 
 class AdminUrlMixin(object):
     """
@@ -16,21 +24,24 @@ class AdminUrlMixin(object):
 
     def _get_url_names(self):
         # Default view names - extend on your model to add extra views
-        return ["edit", "delete", "perms"]
+        return ["add", "edit", "delete", "perms"]
 
     @cached_property
     def urls(self):
         return {
-            view: reverse_lazy(lookup["url_name"], args=lookup["args"])
+            view: reverse_lazy(lookup.url_name, args=lookup.args)
             for view, lookup in self.url_names.items()
         }
 
     @cached_property
-    def url_names(self) -> dict[str, dict[str, tuple]]:
+    def url_names(self) -> dict[str, AdminUrlLookup]:
         namespace = self._get_admin_namespace()
         args = self._get_url_args()
         crud = {
-            name: {"url_name": f"{namespace}:{name}", "args": args}
+            name: AdminUrlLookup(
+                url_name=f"{namespace}:{name}",
+                args=[each for each in args if each is not None],
+            )
             for name in self._get_url_names()
         }
         return crud

--- a/tournamentcontrol/competition/admin.py
+++ b/tournamentcontrol/competition/admin.py
@@ -283,16 +283,6 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
             self.app_name,
         )
 
-        draw_urls = (
-            [
-                # path("", self.list_draw, name="list"),
-                path("build/", self.generate_draw, name="build"),
-                path("undo/", self.undo_draw, name="undo"),
-                path("progress/", self.progress_teams, name="progress"),
-            ],
-            self.app_name,
-        )
-
         undecidedteam_urls = (
             [
                 path(r"add/", self.edit_team, name="add"),
@@ -318,9 +308,11 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
             [
                 path("add/", self.edit_stage, name="add"),
                 path("<int:stage_id>/", self.edit_stage, name="edit"),
+                path("<int:stage_id>/build/", self.generate_draw, name="build"),
+                path("<int:stage_id>/undo/", self.undo_draw, name="undo"),
+                path("<int:stage_id>/progress/", self.progress_teams, name="progress"),
                 path("<int:stage_id>/delete/", self.delete_stage, name="delete"),
                 path("<int:stage_id>/match/", include(match_urls, namespace="match")),
-                path("<int:stage_id>/draw/", include(draw_urls, namespace="draw")),
                 path(
                     "<int:stage_id>/team/",
                     include(undecidedteam_urls, namespace="undecidedteam"),

--- a/tournamentcontrol/competition/models.py
+++ b/tournamentcontrol/competition/models.py
@@ -907,6 +907,9 @@ class Stage(AdminUrlMixin, RankImportanceMixin, OrderedSitemapNode):
             self.pk,
         )
 
+    def _get_url_names(self):
+        return super()._get_url_names() + ["build", "undo", "progress"]
+
     def __str__(self):
         return self.title
 

--- a/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/progression_list.html
+++ b/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/progression_list.html
@@ -1,3 +1,3 @@
 {% extends "tournamentcontrol/competition/progression_list.html" %}
 
-{% block progress_link %}{% url 'admin:fixja:competition:season:division:stage:draw:progress' competition.pk season.pk stage.division.pk stage.pk %}{% endblock %}
+{% block progress_link %}{% url 'admin:fixja:competition:season:division:stage:progress' competition.pk season.pk stage.division.pk stage.pk %}{% endblock %}

--- a/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/stage/list.inc.html
+++ b/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/stage/list.inc.html
@@ -17,13 +17,13 @@
 
 {% block row-buttons-extra %}
 	{% if obj.matches.exists %}
-		{% url 'admin:fixja:competition:season:division:stage:draw:undo' competition.pk season.pk division.pk obj.pk as undo_url %}
+		{% url 'admin:fixja:competition:season:division:stage:undo' competition.pk season.pk division.pk obj.pk as undo_url %}
 		<a class="btn btn-default btn-sm" role="button" href="{{ undo_url }}" data-toggle="modal" data-target="#undoModal_stage" data-action="{{ undo_url }}" data-title="{{ obj }}">
 			<i class="fa fa-eject"></i>
 			&nbsp;{% trans "Undo" %} <span class="badge">{{ obj.matches.count }}</span>
 		</a>
 	{% else %}
-		<a class="btn btn-default btn-sm" href="{% url 'admin:fixja:competition:season:division:stage:draw:build' competition.pk season.pk division.pk obj.pk %}" role="button">
+		<a class="btn btn-default btn-sm" href="{% url 'admin:fixja:competition:season:division:stage:build' competition.pk season.pk division.pk obj.pk %}" role="button">
 			<i class="fa fa-play"></i>
 			&nbsp;{% trans "Build" %}
 		</a>

--- a/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/stage/list.inc.html
+++ b/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/stage/list.inc.html
@@ -17,13 +17,12 @@
 
 {% block row-buttons-extra %}
 	{% if obj.matches.exists %}
-		{% url 'admin:fixja:competition:season:division:stage:undo' competition.pk season.pk division.pk obj.pk as undo_url %}
-		<a class="btn btn-default btn-sm" role="button" href="{{ undo_url }}" data-toggle="modal" data-target="#undoModal_stage" data-action="{{ undo_url }}" data-title="{{ obj }}">
+		<a class="btn btn-default btn-sm" role="button" href="{{ obj.urls.undo }}" data-toggle="modal" data-target="#undoModal_stage" data-action="{{ obj.urls.undo }}" data-title="{{ obj }}">
 			<i class="fa fa-eject"></i>
 			&nbsp;{% trans "Undo" %} <span class="badge">{{ obj.matches.count }}</span>
 		</a>
 	{% else %}
-		<a class="btn btn-default btn-sm" href="{% url 'admin:fixja:competition:season:division:stage:build' competition.pk season.pk division.pk obj.pk %}" role="button">
+		<a class="btn btn-default btn-sm" href="{{ obj.urls.build }}" role="button">
 			<i class="fa fa-play"></i>
 			&nbsp;{% trans "Build" %}
 		</a>

--- a/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/widgets/progress/stages.html
+++ b/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/widgets/progress/stages.html
@@ -20,7 +20,7 @@
 								<ul>
 									{% for stage in object_list %}
 										{% with competition=stage.division.season.competition season=stage.division.season division=stage.division %}
-											<li><a href="{% url 'admin:fixja:competition:season:division:stage:draw:progress' competition.pk season.pk division.pk stage.pk %}">{{ stage.title }}</a></li>
+											<li><a href="{% url 'admin:fixja:competition:season:division:stage:progress' competition.pk season.pk division.pk stage.pk %}">{{ stage.title }}</a></li>
 										{% endwith %}
 									{% endfor %}
 								</ul>

--- a/tournamentcontrol/competition/tests/test_competition_admin.py
+++ b/tournamentcontrol/competition/tests/test_competition_admin.py
@@ -403,6 +403,9 @@ class GoodViewTests(TestCase):
             division=division, size=2
         )
 
+        url_rounds = round_games.url_names["progress"]
+        url_finals = finals.url_names["progress"]
+
         for round in round_robin(teams):
             for home_team, away_team in round:
                 factories.MatchFactory.create(
@@ -443,18 +446,12 @@ class GoodViewTests(TestCase):
             away_team_eval_related=semi_2,
         )
 
-        self.assertLoginRequired(
-            round_games._get_admin_namespace() + ":draw:progress",
-            *round_games._get_url_args(),
-        )
+        self.assertLoginRequired(url_rounds["url_name"], *url_rounds["args"])
 
         with self.login(self.superuser):
             # The round games cannot be progressed, it's the first stage and
             # therefore can't have any undecided teams.
-            self.get(
-                round_games._get_admin_namespace() + ":draw:progress",
-                *round_games._get_url_args(),
-            )
+            self.get(url_rounds["url_name"], *url_rounds["args"])
             self.response_410()
 
             # FIXME
@@ -472,10 +469,7 @@ class GoodViewTests(TestCase):
             #     m.away_team_score = random.randint(0, 20)
 
             # The final series progression should now be accessible.
-            self.get(
-                finals._get_admin_namespace() + ":draw:progress",
-                *finals._get_url_args(),
-            )
+            self.get(url_finals["url_name"], *url_finals["args"])
             self.response_200()
 
     def test_edit_person(self):

--- a/tournamentcontrol/competition/tests/test_competition_admin.py
+++ b/tournamentcontrol/competition/tests/test_competition_admin.py
@@ -900,45 +900,45 @@ class BackendTests(TestCase):
             stage=stage, home_team=home, away_team=None, away_team_undecided=away
         )
 
-        edit_away = away.url_names["edit"]
-        delete_away = away.url_names["delete"]
-        delete_url = away.urls["delete"]
+        delete_url = self.reverse(
+            away._get_admin_namespace() + ":delete", *away._get_url_args()
+        )
 
         # Ensure the edit view response does not include a delete button.
-        self.get(edit_away.url_name, *edit_away.args)
+        self.get(away._get_admin_namespace() + ":edit", *away._get_url_args())
         self.assertResponseNotContains(delete_url, html=False)
 
         # Ensure that visiting the delete view does not respond when matches
         # are associated with the Team.
-        self.get(delete_away.url_name, *delete_away.args)
+        self.get(away._get_admin_namespace() + ":delete", *away._get_url_args())
         self.response_410()
 
         # Ensure that POST to the delete view fails the same as for GET.
-        self.post(delete_away.url_name, *delete_away.args)
+        self.post(away._get_admin_namespace() + ":delete", *away._get_url_args())
         self.response_410()
 
         # Create a new UndecidedTeam and re-check the scenarios.
         team = factories.UndecidedTeamFactory.create(stage=stage)
 
-        edit_team = team.url_names["edit"]
-        delete_team = team.url_names["delete"]
-        delete_url = team.urls["delete"]
+        delete_url = self.reverse(
+            team._get_admin_namespace() + ":delete", *team._get_url_args()
+        )
 
         # Ensure the edit view response *does* include a delete button.
-        self.get(edit_team.url_name, *edit_team.args)
+        self.get(stage._get_admin_namespace() + ":edit", *stage._get_url_args())
         self.assertResponseContains(delete_url, html=False)
 
         # Ensure that visiting the delete view is not allowed when there are no
         # matches but you use a GET request.
-        self.get(delete_team.url_name, *delete_team.args)
+        self.get(team._get_admin_namespace() + ":delete", *team._get_url_args())
         self.response_405()
 
         # Ensure that POST to the delete view redirects.
-        self.post(delete_team.url_name, *delete_team.args)
+        self.post(team._get_admin_namespace() + ":delete", *team._get_url_args())
         self.response_302()
 
         # Subsequent GET request to the edit view should be a 404.
-        self.get(delete_team.url_name, *delete_team.args)
+        self.get(team._get_admin_namespace() + ":delete", *team._get_url_args())
         self.response_404()
 
     @unittest.skipIf(

--- a/tournamentcontrol/competition/tests/test_competition_admin.py
+++ b/tournamentcontrol/competition/tests/test_competition_admin.py
@@ -461,7 +461,7 @@ class GoodViewTests(TestCase):
             #
             # # The final series can't be progressed because there are results
             # # that need to be entered for matches in the preceding stage.
-            # self.get(finals._get_admin_namespace() + ':draw:progress',
+            # self.get(finals._get_admin_namespace() + ':progress',
             #          *finals._get_url_args())
             # self.response_410()
             #

--- a/tournamentcontrol/competition/tests/test_formsets.py
+++ b/tournamentcontrol/competition/tests/test_formsets.py
@@ -53,7 +53,7 @@ class DrawGenerationMatchFormSetTest(TestCase):
 
         with self.login(self.superuser):
             self.post(
-                "admin:fixja:competition:season:division:stage:draw:build",
+                "admin:fixja:competition:season:division:stage:build",
                 self.stage.division.season.competition.pk,
                 self.stage.division.season.pk,
                 self.stage.division.pk,
@@ -85,7 +85,7 @@ class DrawGenerationMatchFormSetTest(TestCase):
                 )
 
             self.post(
-                "admin:fixja:competition:season:division:stage:draw:build",
+                "admin:fixja:competition:season:division:stage:build",
                 self.stage.division.season.competition.pk,
                 self.stage.division.season.pk,
                 self.stage.division.pk,
@@ -145,7 +145,7 @@ class DrawGenerationMatchFormSetTest(TestCase):
 
         with self.login(self.superuser):
             self.post(
-                "admin:fixja:competition:season:division:stage:draw:build",
+                "admin:fixja:competition:season:division:stage:build",
                 stage.division.season.competition.pk,
                 stage.division.season.pk,
                 stage.division.pk,
@@ -177,7 +177,7 @@ class DrawGenerationMatchFormSetTest(TestCase):
                 )
 
             self.post(
-                "admin:fixja:competition:season:division:stage:draw:build",
+                "admin:fixja:competition:season:division:stage:build",
                 stage.division.season.competition.pk,
                 stage.division.season.pk,
                 stage.division.pk,


### PR DESCRIPTION
This pull request introduces significant refactoring and enhancements to the URL handling in the admin interface of the competition management system. The changes aim to improve code maintainability, reduce redundancy, and streamline URL generation by leveraging a new `AdminUrlLookup` dataclass. Additionally, the pull request includes updates to templates, tests, and models to align with the new URL handling approach.

### Refactoring and URL Handling Improvements:
* Introduced a `@dataclass` called `AdminUrlLookup` in `touchtechnology/admin/mixins.py` to encapsulate URL name and arguments, replacing the previous dictionary-based approach. (`[touchtechnology/admin/mixins.pyR4-R11](diffhunk://#diff-8f259773f86e1d7674caa34ef753c57ddda2d3791190826ce5c2e76c87b4e9b8R4-R11)`)
* Updated `AdminUrlMixin` methods to use the `AdminUrlLookup` dataclass for cleaner and more structured URL handling. (`[touchtechnology/admin/mixins.pyL19-R44](diffhunk://#diff-8f259773f86e1d7674caa34ef753c57ddda2d3791190826ce5c2e76c87b4e9b8L19-R44)`)
* Extended `_get_url_names` in `tournamentcontrol/competition/models.py` to include additional views such as "build," "undo," and "progress" for stages. (`[tournamentcontrol/competition/models.pyR910-R912](diffhunk://#diff-7d952f5acc74581a7758503a601e43379d6d1438ed1f198ae07c4003f54bc337R910-R912)`)

### Template Updates:
* Simplified URL references in templates by using the new `AdminUrlLookup`-based approach, replacing hardcoded URL patterns with object-based URLs (e.g., `{{ obj.urls.build }}`). (`[[1]](diffhunk://#diff-d31d0559d1b65efcfd07a47112bbb4de9149652ecf8ca2b212b5e695bdf92520L20-R25)`, `[[2]](diffhunk://#diff-ab7787983bf33016d2fee32d07c557a94e13dd7e8937ad9f8d850faa9fe0aaf3L23-R23)`, `[[3]](diffhunk://#diff-b4f85f0f73b3af7c4295be0589159d13f94e971484fa2875acfde640af9625eeL3-R3)`)

### Functional Enhancements:
* Consolidated draw-related URLs into the stage-specific URL namespace, removing the separate "draw" namespace and adding "build," "undo," and "progress" endpoints directly under stages. (`[[1]](diffhunk://#diff-88db814990a0b6e8f87e4887fa7dabd59536f2104f400aec77f780a3faf8a7a5L286-L295)`, `[[2]](diffhunk://#diff-88db814990a0b6e8f87e4887fa7dabd59536f2104f400aec77f780a3faf8a7a5R311-L323)`)

### Test Updates:
* Refactored tests to use the `AdminUrlLookup` dataclass for URL assertions, replacing manual namespace concatenation and argument handling. This change improves test clarity and reduces duplication. (`[[1]](diffhunk://#diff-6a3fc53b4be5051f51b6edbce5ca5a5160d1acb41ab99e33fac4e0514e72aeacR406-R408)`, `[[2]](diffhunk://#diff-6a3fc53b4be5051f51b6edbce5ca5a5160d1acb41ab99e33fac4e0514e72aeacL570-L599)`, `[[3]](diffhunk://#diff-6a3fc53b4be5051f51b6edbce5ca5a5160d1acb41ab99e33fac4e0514e72aeacL869-R887)`, `[[4]](diffhunk://#diff-6a3fc53b4be5051f51b6edbce5ca5a5160d1acb41ab99e33fac4e0514e72aeacL1060-R1034)`)

### Minor Changes:
* Updated imports in `tournamentcontrol/competition/tests/test_competition_admin.py` to include additional models required for testing. (`[tournamentcontrol/competition/tests/test_competition_admin.pyL11-R11](diffhunk://#diff-6a3fc53b4be5051f51b6edbce5ca5a5160d1acb41ab99e33fac4e0514e72aeacL11-R11)`)