### PR TITLE
Add venue match listing views

### DIFF
--- a/tournamentcontrol/competition/templates/tournamentcontrol/competition/ground.html
+++ b/tournamentcontrol/competition/templates/tournamentcontrol/competition/ground.html
@@ -1,0 +1,26 @@
+{% extends "tournamentcontrol/competition/base.html" %}
+{% load i18n %}
+
+{% block page_title %}{{ competition.title }} - {{ season.title }} - {{ venue.title }} - {{ ground.title }}{% endblock %}
+
+{% block content %}
+<h1>{% trans competition.title %} - {% trans season.title %}</h1>
+<h2>{% trans venue.title %} - {% trans ground.title %}</h2>
+
+<ul id="dates">
+{% for d in dates %}
+    <li><a href="{{ d|date:'Ymd' }}/">{{ d|date }}</a></li>
+{% endfor %}
+</ul>
+
+{% for date, matches in matches_by_date.items %}
+<h3>{{ date }}</h3>
+<table class="draw">
+<tbody>
+{% for match in matches %}
+<tr><td class="time">{{ match.datetime|time }}</td><td>{{ match.get_home_team.title }}</td><td>{{ match.get_away_team.title }}</td></tr>
+{% endfor %}
+</tbody>
+</table>
+{% endfor %}
+{% endblock %}

--- a/tournamentcontrol/competition/templates/tournamentcontrol/competition/venue.html
+++ b/tournamentcontrol/competition/templates/tournamentcontrol/competition/venue.html
@@ -1,0 +1,32 @@
+{% extends "tournamentcontrol/competition/base.html" %}
+{% load i18n %}
+
+{% block page_title %}{{ competition.title }} - {{ season.title }} - {{ venue.title }}{% endblock %}
+
+{% block content %}
+<h1>{% trans competition.title %} - {% trans season.title %}</h1>
+<h2>{% trans venue.title %}</h2>
+
+<ul id="grounds">
+{% for g in grounds %}
+    <li><a href="{{ g.urls.view }}">{{ g.title }}</a></li>
+{% endfor %}
+</ul>
+
+<ul id="dates">
+{% for d in dates %}
+    <li><a href="{{ d|date:'Ymd' }}/">{{ d|date }}</a></li>
+{% endfor %}
+</ul>
+
+{% for date, matches in matches_by_date.items %}
+<h3>{{ date }}</h3>
+<table class="draw">
+<tbody>
+{% for match in matches %}
+<tr><td class="time">{{ match.datetime|time }}</td><td class="field">{{ match.play_at.title }}</td><td>{{ match.get_home_team.title }}</td><td>{{ match.get_away_team.title }}</td></tr>
+{% endfor %}
+</tbody>
+</table>
+{% endfor %}
+{% endblock %}

--- a/tournamentcontrol/competition/tests/test_competition_site.py
+++ b/tournamentcontrol/competition/tests/test_competition_site.py
@@ -165,6 +165,59 @@ class GoodViewTests(TestCase):
             )
             self.response_410()
 
+    def test_venue(self):
+        venue = factories.VenueFactory.create()
+        factories.MatchFactory.create(play_at=venue, stage__division__season=venue.season)
+        self.assertGoodView(
+            "competition:venue",
+            venue.season.competition.slug,
+            venue.season.slug,
+            venue.slug,
+        )
+
+    def test_venue_date(self):
+        match = factories.MatchFactory.create()
+        match.play_at = factories.VenueFactory.create(season=match.stage.division.season)
+        match.save()
+        datestr = match.date.strftime("%Y%m%d")
+        self.assertGoodView(
+            "competition:venue",
+            match.stage.division.season.competition.slug,
+            match.stage.division.season.slug,
+            match.play_at.slug,
+            datestr,
+        )
+
+    def test_ground(self):
+        ground = factories.GroundFactory.create()
+        factories.MatchFactory.create(play_at=ground, stage__division__season=ground.venue.season)
+        self.assertGoodView(
+            "competition:ground",
+            ground.venue.season.competition.slug,
+            ground.venue.season.slug,
+            ground.venue.slug,
+            ground.slug,
+        )
+
+    def test_ground_date(self):
+        ground = factories.GroundFactory.create()
+        match = factories.MatchFactory.create(
+            play_at=ground,
+            stage__division__season=ground.venue.season,
+            date="2025-03-13",
+            time="10:00",
+            datetime="2025-03-13 10:00",
+        )
+        datestr = match.date.strftime("%Y%m%d")
+        self.assertGoodView(
+            "competition:ground",
+            ground.venue.season.competition.slug,
+            ground.venue.season.slug,
+            ground.venue.slug,
+            ground.slug,
+            datestr,
+        )
+
 
 @override_settings(ROOT_URLCONF="tournamentcontrol.competition.tests.urls")
 class FrontEndTests(TestCase):


### PR DESCRIPTION
## Summary
- add venue URLs to season routing
- implement venue and ground views listing matches by date
- add templates for venue and ground listings
- test venue and ground views

## Testing
- `tox -q -e dj52-py312` *(fails: Error while fetching server API version)*

------
https://chatgpt.com/codex/tasks/task_e_68624a03239c8324a60e40ddb5bfa143