### PR TITLE
fix: update URL lookup fields in `ListDivisionSerializer` and `ListSeasonSerializer`

### DIFF
--- a/tournamentcontrol/competition/rest/v1/season.py
+++ b/tournamentcontrol/competition/rest/v1/season.py
@@ -48,8 +48,8 @@ class ListDivisionSerializer(NestedHyperlinkedModelSerializer):
         model = models.Division
         fields = ("title", "slug", "url")
         extra_kwargs = {
-            "url": {"lookup_field": "slug"},
-            "division": {"lookup_field": "slug"},
+            "url": {"lookup_field": "slug", "view_name": "v1:division-detail"},
+            "season": {"lookup_field": "slug"},
         }
 
 
@@ -60,7 +60,7 @@ class ListSeasonSerializer(NestedHyperlinkedModelSerializer):
         model = models.Season
         fields = ("title", "slug", "url")
         extra_kwargs = {
-            "url": {"lookup_field": "slug"},
+            "url": {"lookup_field": "slug", "view_name": "v1:season-detail"},
             "competition": {"lookup_field": "slug"},
         }
 

--- a/tournamentcontrol/competition/tests/test_rest_api_v1.py
+++ b/tournamentcontrol/competition/tests/test_rest_api_v1.py
@@ -1,10 +1,8 @@
 import unittest
 
 from django.test.utils import override_settings
-from django.urls import resolve
 from test_plus import TestCase
 
-from tournamentcontrol.competition.models import Match
 from tournamentcontrol.competition.tests import factories
 
 
@@ -71,9 +69,6 @@ class APITests(TestCase):
         self.get("v1:competition-detail", slug=self.competition.slug)
         self.response_200()
 
-    @unittest.skip(
-        'Could not resolve URL for hyperlinked relationship using view name "season-detail"'
-    )
     def test_season_list(self):
         """Test season-list endpoint"""
         self.get(
@@ -82,9 +77,6 @@ class APITests(TestCase):
         )
         self.response_200()
 
-    @unittest.skip(
-        'Could not resolve URL for hyperlinked relationship using view name "season-detail"'
-    )
     def test_season_detail(self):
         """Test season-detail endpoint"""
         self.get(
@@ -166,7 +158,9 @@ class APITests(TestCase):
                                 "round": f"Round {self.match.round}",
                                 "date": self.match.date.isoformat(),
                                 "time": self.match.time.isoformat(),
-                                "datetime": self.match.datetime.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                                "datetime": self.match.datetime.strftime(
+                                    "%Y-%m-%dT%H:%M:%S.%fZ"
+                                ),
                                 "is_bye": False,
                                 "is_washout": False,
                                 "home_team": self.team1.id,


### PR DESCRIPTION
This completes the testing added in #124 and removes the temporary skips that were in place.