### PR TITLE
Add `.github/release.yml`

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+changelog:
+  categories:
+    - title: ":loudspeaker: Updates"
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - bug
+          - dependencies
+          - maintenance
+    - title: ":lady_beetle: Bug fixes"
+      labels:
+        - bug
+    - title: ":broom: Maintenance"
+      labels:
+        - maintenance
+    - title: ":wrench: Dependencies"
+      labels:
+        - dependencies


### PR DESCRIPTION
This pull request updates the `.github/release.yml` file to define changelog categories for organizing release notes. The categories include updates, bug fixes, maintenance, and dependencies.

Release notes organization:

* Added four changelog categories (`Updates`, `Bug fixes`, `Maintenance`, and `Dependencies`) with corresponding labels to streamline release note generation.