### PR TITLE
Fix failure to call the YouTube API in `edit_match` admin view

### DIFF
--- a/tournamentcontrol/competition/admin.py
+++ b/tournamentcontrol/competition/admin.py
@@ -1529,7 +1529,8 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
             match = Match(stage=stage, include_in_ladder=stage.keep_ladder)
 
         def pre_save_callback(obj: Match):
-            # Check if YouTube credentials are configured before attempting API calls
+            # Check if YouTube credentials are configured before attempting anything else,
+            # we can't interact with the YouTube API without them.
             if not (season.live_stream_client_id and season.live_stream_client_secret):
                 return obj
 
@@ -1651,11 +1652,7 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
             post_save_redirect=self.redirect(
                 request.GET.get("next") or stage.urls["edit"]
             ),
-            pre_save_callback=(
-                pre_save_callback
-                if season.live_stream and match.live_stream
-                else lambda o: o
-            ),
+            pre_save_callback=pre_save_callback if season.live_stream else lambda o: o,
             permission_required=True,
             extra_context=extra_context,
         )


### PR DESCRIPTION
In #97 I naively added a check that would stop the `pre_save_callback` being executed when the value of `Match.live_stream` was false.

However, this is the pre-save value. At the time we evaluate it, the form has not been processed. Thus, a match that is transitioning from `False` to `True` will never fire the callback, so the YouTube resource is never created.

This is still sub-optimal and may cause other issues (see #85), but I don't have time to spend on it now.