### PR TITLE
Add Russian month names support in `parse_month_name` function

### DIFF
--- a/touchtechnology/news/decorators.py
+++ b/touchtechnology/news/decorators.py
@@ -83,6 +83,7 @@ def parse_month_name(month_str):
         "vi",
         "id",
         "ms",
+        "ru",
     ]
 
     for locale_code in locales:

--- a/touchtechnology/news/tests/test_decorators.py
+++ b/touchtechnology/news/tests/test_decorators.py
@@ -68,6 +68,8 @@ class ParseMonthNameTest(TestCase):
             ("marzo", 3),  # Spanish March
             ("mars", 3),  # French March
             ("märz", 3),  # German March
+            ("июль", 7),  # Russian July
+            ("июл", 7),  # Abbreviated Russian July
         ]
 
         for month_str, expected_num in test_cases:


### PR DESCRIPTION
This pull request adds support for parsing Russian month names in the `parse_month_name` function and includes corresponding test cases to ensure the functionality works as expected.

### Localization updates:
* Added "ru" (Russian) to the list of supported locales in the `parse_month_name` function in `touchtechnology/news/decorators.py`.

### Test coverage:
* Added test cases for Russian month names ("июль" for July and its abbreviation "июл") in the `test_babel_supported_localized_names` method in `touchtechnology/news/tests/test_decorators.py`.

Refs: #126.