### PR TITLE
Fix: Exclude non-ladder matches from result entry requirements

### DIFF
--- a/tournamentcontrol/competition/dashboard.py
+++ b/tournamentcontrol/competition/dashboard.py
@@ -43,6 +43,7 @@ def matches_require_basic_results(now=None, matches=None):
         home_team_score=None,
         away_team_score=None,
         is_washout=False,
+        include_in_ladder=True,
     ).select_related(
         "stage__division__season__competition",
         "play_at",


### PR DESCRIPTION
## Summary
- Fixed tournament control logic to exclude matches with `include_in_ladder=False` from requiring result entry
- Modified `matches_require_basic_results()` function in `dashboard.py`

## Problem
Currently, the system requires result entry for ALL matches regardless of their `include_in_ladder` setting. This creates unnecessary administrative overhead for tournament organizers when dealing with exhibition/friendly matches.

## Solution
Added `include_in_ladder=True` filter to ensure only ladder matches (those that count toward standings) require result entry.

## Test plan
- [ ] Verify matches with `include_in_ladder=False` no longer appear in result entry workflows
- [ ] Confirm ladder matches still require result entry as expected
- [ ] Test with various match types (regular, exhibition, friendly)

🤖 Generated with [Claude Code](https://claude.ai/code)