### PR TITLE
feat: add flutter mobile prototype with ladder

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -1,0 +1,49 @@
+name: mobile
+
+on:
+  push:
+    paths:
+      - 'src/mobile/**'
+      - '.github/workflows/mobile.yml'
+  pull_request:
+    paths:
+      - 'src/mobile/**'
+      - '.github/workflows/mobile.yml'
+
+jobs:
+  android:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/mobile
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: flutter test
+      - run: flutter build apk --debug
+      - uses: actions/upload-artifact@v4
+        with:
+          name: android-apk
+          path: build/app/outputs/flutter-apk/app-debug.apk
+
+  ios:
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: src/mobile
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: flutter test
+      - run: flutter build ios --no-codesign
+      - run: cd build/ios/iphoneos && zip -r app.zip Runner.app
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ios-app
+          path: build/ios/iphoneos/app.zip

--- a/src/mobile/assets/images/logo.png
+++ b/src/mobile/assets/images/logo.png
@@ -1,0 +1,1 @@
+placeholder

--- a/src/mobile/lib/main.dart
+++ b/src/mobile/lib/main.dart
@@ -1,0 +1,234 @@
+import 'package:flutter/material.dart';
+import 'models.dart';
+import 'services.dart';
+
+void main() {
+  runApp(const TournamentApp());
+}
+
+class TournamentApp extends StatelessWidget {
+  const TournamentApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Tournament',
+      theme: ThemeData(useMaterial3: true),
+      routes: {
+        '/': (_) => const HomePage(),
+        '/competitions': (_) => const CompetitionsPage(),
+      },
+      onGenerateRoute: (settings) {
+        if (settings.name == SeasonPage.routeName) {
+          final event = settings.arguments as Event;
+          return MaterialPageRoute(builder: (_) => SeasonPage(event: event));
+        }
+        if (settings.name == DivisionPage.routeName) {
+          final season = settings.arguments as Season;
+          return MaterialPageRoute(builder: (_) => DivisionPage(season: season));
+        }
+        if (settings.name == FixturesPage.routeName) {
+          final division = settings.arguments as Division;
+          return MaterialPageRoute(builder: (_) => FixturesPage(division: division));
+        }
+        return null;
+      },
+    );
+  }
+}
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final api = ApiService();
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('News'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.emoji_events),
+            onPressed: () => Navigator.pushNamed(context, '/competitions'),
+          ),
+        ],
+      ),
+      body: FutureBuilder<List<NewsItem>>(
+        future: api.fetchNews(),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final news = snapshot.data!;
+          return ListView.builder(
+            itemCount: news.length,
+            itemBuilder: (context, index) {
+              final item = news[index];
+              return ListTile(title: Text(item.title), subtitle: Text(item.body));
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class CompetitionsPage extends StatelessWidget {
+  const CompetitionsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final api = ApiService();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Competitions')),
+      body: FutureBuilder<List<Event>>(
+        future: api.fetchEvents(),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final events = snapshot.data!;
+          return GridView.count(
+            crossAxisCount: 2,
+            children: [
+              for (final e in events)
+                GestureDetector(
+                  onTap: () {
+                    if (e.seasons.length > 1) {
+                      Navigator.pushNamed(context, SeasonPage.routeName, arguments: e);
+                    } else {
+                      Navigator.pushNamed(context, DivisionPage.routeName, arguments: e.seasons.first);
+                    }
+                  },
+                  child: Card(child: Center(child: Text(e.name))),
+                ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class SeasonPage extends StatelessWidget {
+  static const routeName = '/season';
+  final Event event;
+  const SeasonPage({super.key, required this.event});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(event.name)),
+      body: ListView(
+        children: [
+          for (final season in event.seasons)
+            ListTile(
+              title: Text(season.year.toString()),
+              onTap: () => Navigator.pushNamed(context, DivisionPage.routeName, arguments: season),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class DivisionPage extends StatelessWidget {
+  static const routeName = '/division';
+  final Season season;
+  const DivisionPage({super.key, required this.season});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Divisions ${season.year}')),
+      body: ListView(
+        children: [
+          for (final d in season.divisions)
+            ListTile(
+              title: Text(d.name),
+              onTap: () => Navigator.pushNamed(context, FixturesPage.routeName, arguments: d),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class FixturesPage extends StatelessWidget {
+  static const routeName = '/fixtures';
+  final Division division;
+  const FixturesPage({super.key, required this.division});
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(division.name),
+          bottom: const TabBar(tabs: [Tab(text: 'Fixtures'), Tab(text: 'Ladder')]),
+        ),
+        body: TabBarView(
+          children: [
+            _FixturesList(fixtures: division.fixtures),
+            _LadderView(entries: division.ladder),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FixturesList extends StatelessWidget {
+  final List<Fixture> fixtures;
+  const _FixturesList({required this.fixtures});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      children: [
+        for (final f in fixtures)
+          ListTile(
+            title: Text('${f.teamA} vs ${f.teamB}'),
+            subtitle: Text('${f.time} - ${f.field}'),
+            trailing: Text(f.result ?? ''),
+          ),
+      ],
+    );
+  }
+}
+
+class _LadderView extends StatelessWidget {
+  final List<LadderEntry> entries;
+  const _LadderView({required this.entries});
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: DataTable(
+        columns: const [
+          DataColumn(label: Text('Team')),
+          DataColumn(label: Text('P')),
+          DataColumn(label: Text('W')),
+          DataColumn(label: Text('D')),
+          DataColumn(label: Text('L')),
+          DataColumn(label: Text('Pts')),
+          DataColumn(label: Text('GD')),
+        ],
+        rows: [
+          for (final e in entries)
+            DataRow(cells: [
+              DataCell(Text(e.team)),
+              DataCell(Text(e.played.toString())),
+              DataCell(Text(e.wins.toString())),
+              DataCell(Text(e.draws.toString())),
+              DataCell(Text(e.losses.toString())),
+              DataCell(Text(e.points.toString())),
+              DataCell(Text(e.goalDiff.toString())),
+            ])
+        ],
+      ),
+    );
+  }
+}

--- a/src/mobile/lib/models.dart
+++ b/src/mobile/lib/models.dart
@@ -1,0 +1,45 @@
+class NewsItem {
+  final String title;
+  final String body;
+  NewsItem({required this.title, required this.body});
+}
+
+class Event {
+  final String name;
+  final String logo;
+  final List<Season> seasons;
+  Event({required this.name, required this.logo, required this.seasons});
+}
+
+class Season {
+  final int year;
+  final List<Division> divisions;
+  Season({required this.year, required this.divisions});
+}
+
+class Division {
+  final String name;
+  final List<Fixture> fixtures;
+  final List<LadderEntry> ladder;
+  Division({required this.name, required this.fixtures, required this.ladder});
+}
+
+class Fixture {
+  final String teamA;
+  final String teamB;
+  final String time;
+  final String field;
+  final String? result;
+  Fixture({required this.teamA, required this.teamB, required this.time, required this.field, this.result});
+}
+
+class LadderEntry {
+  final String team;
+  final int played;
+  final int wins;
+  final int draws;
+  final int losses;
+  final int points;
+  final int goalDiff;
+  LadderEntry({required this.team, required this.played, required this.wins, required this.draws, required this.losses, required this.points, required this.goalDiff});
+}

--- a/src/mobile/lib/services.dart
+++ b/src/mobile/lib/services.dart
@@ -1,0 +1,36 @@
+import 'models.dart';
+
+class ApiService {
+  Future<List<NewsItem>> fetchNews() async {
+    return [
+      NewsItem(title: 'Welcome to the Tournament', body: 'Stay tuned for updates'),
+      NewsItem(title: 'Finals Approaching', body: 'Big games this weekend'),
+    ];
+  }
+
+  Future<List<Event>> fetchEvents() async {
+    return _events;
+  }
+}
+
+final _ladder = [
+  LadderEntry(team: 'ThunderCats', played: 3, wins: 3, draws: 0, losses: 0, points: 9, goalDiff: 12),
+  LadderEntry(team: 'StormBreakers', played: 3, wins: 2, draws: 0, losses: 1, points: 6, goalDiff: 5),
+];
+
+final _fixtures = [
+  Fixture(teamA: 'ThunderCats', teamB: 'StormBreakers', time: '3:00 PM', field: 'Field 1', result: '2-1'),
+  Fixture(teamA: 'Wildcats', teamB: 'Eagles', time: '4:00 PM', field: 'Field 2', result: null),
+];
+
+final _divisions = [
+  Division(name: "Men's Open", fixtures: _fixtures, ladder: _ladder),
+  Division(name: "Women's 40s", fixtures: _fixtures, ladder: _ladder),
+];
+
+final _events = [
+  Event(name: 'Summer Cup', logo: 'assets/images/logo.png', seasons: [
+    Season(year: 2024, divisions: _divisions),
+    Season(year: 2025, divisions: _divisions),
+  ]),
+];

--- a/src/mobile/pubspec.yaml
+++ b/src/mobile/pubspec.yaml
@@ -1,0 +1,21 @@
+name: tournament_app
+description: Sports tournament prototype
+publish_to: 'none'
+version: 0.1.0
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.6
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/images/

--- a/src/mobile/test/widget_test.dart
+++ b/src/mobile/test/widget_test.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tournament_app/main.dart';
+
+void main() {
+  testWidgets('App builds', (tester) async {
+    await tester.pumpWidget(const TournamentApp());
+    expect(find.text('News'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add Flutter app prototype for tournament browsing with ladder view
- stub API service with static data and simple models
- build Android and iOS artifacts in CI with Flutter

## Testing
- `flutter pub get`
- `flutter test` *(fails: command hung without output)*
- `pytest` *(errors: ModuleNotFoundError: django, test_plus, yaml, playwright, imp)*

------
https://chatgpt.com/codex/tasks/task_e_68a026e7d89c832486c4dac0ce2ed0bc