### PR TITLE
Fix ladder calculation issues when matches are scheduled across pools

### DIFF
--- a/tournamentcontrol/competition/models.py
+++ b/tournamentcontrol/competition/models.py
@@ -1293,13 +1293,9 @@ class StageGroup(AdminUrlMixin, RankImportanceMixin, OrderedSitemapNode):
 
     @property
     def ladder(self):
-        team_ids = set()
-        for m in self.matches.all():
-            if m.home_team is not None:
-                team_ids.add(m.home_team_id)
-            if m.away_team is not None:
-                team_ids.add(m.away_team_id)
-        return LadderSummary.objects.filter(stage=self.stage, team__in=team_ids)
+        return LadderSummary.objects.filter(
+            stage=self.stage, team__in=self.teams.values_list("pk", flat=True)
+        )
 
     def ladders(self):
         return {self: self.ladder_summary.select_related("team__club")}

--- a/tournamentcontrol/competition/signals/ladders.py
+++ b/tournamentcontrol/competition/signals/ladders.py
@@ -185,5 +185,7 @@ def team_ladder_entry_aggregation(sender, instance, created=None, *args, **kwarg
     aggregate.update({"percentage": percentage})
 
     instance.team.ladder_summary.create(
-        stage=instance.match.stage, stage_group=instance.match.stage_group, **aggregate
+        stage=instance.match.stage,
+        stage_group=instance.team.stage_group,
+        **aggregate,
     )


### PR DESCRIPTION
When matches were played between teams in the same `Division`, but not in the same pool, the `LadderSummary` would not reflect this match in the `StageGroup` ladder of each team.

This updates the behaviour for this unusual case.