### PR TITLE
Fix dependency on Django to be >=4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "django-modelforms",
     "django-mptt",
     "django-timezone-field",
-    "django>=3.2",
+    "django>=4.2",
     "first",
     "namedentities",
     "psycopg",


### PR DESCRIPTION
We only test 4.2+ but the `pyproject.toml` was not updated.
