### PR TITLE
Update Django 6.0 test matrix for final release

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ stable as possible for as long as possible.
 
 As of this release, we target and test against:
 - Django 4.2 and 5.2 (LTS releases) with Python 3.11, 3.12, and 3.13
-- Django 5.2 with Python 3.14 (when available)
-- Django 6.0 (pre-release) with Python 3.12, 3.13, and 3.14 (when available)
+- Django 5.2 (latest patch releases) with Python 3.14 (when available)
+- Django 6.0 with Python 3.12, 3.13, and 3.14 (when available)
 
-**Note**: Testing dimensions for Django 6.0 and Python 3.14 are configured but will be skipped if the versions
-are not yet available (`skip_missing_interpreters = true` in tox.ini).
+**Note**: Testing dimensions for Python 3.14 are configured but will be skipped if the version
+is not yet available (`skip_missing_interpreters = true` in tox.ini).
 
 [wiktionary word of the day]: https://en.wiktionary.org/wiki/Wiktionary:Word_of_the_day

--- a/tests/README.md
+++ b/tests/README.md
@@ -37,7 +37,7 @@ uvx tox
 ```bash
 uvx tox -e dj52-py311  # Django 5.2 with Python 3.11
 uvx tox -e dj42-py312  # Django 4.2 with Python 3.12
-uvx tox -e dj60-py314  # Django 6.0 (pre-release) with Python 3.14
+uvx tox -e dj60-py314  # Django 6.0 with Python 3.14
 ```
 
 ### Run specific unit test modules with specific Django/Python combination

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     dj42-py{311, 312, 313}  # EOL 30 Apr 2026
     dj52-py{311, 312, 313, 314}  # EOL 30 Apr 2028
-    dj60-py{312, 313, 314}  # Django 6.0 pre-release
+    dj60-py{312, 313, 314}  # Django 6.0
     e2e
 skip_missing_interpreters = true
 requires =
@@ -14,7 +14,7 @@ package = editable
 deps =
     dj42: Django~=4.2.0
     dj52: Django~=5.2.0
-    dj60: Django>=6.0a1,<6.1
+    dj60: Django>=6.0,<6.1
 dependency_groups = test
 extras =
     admin


### PR DESCRIPTION
## Summary
- update tox configuration to target the Django 6.0 final release
- refresh documentation to describe current Django/Python support, including Python 3.14 on Django 5.2

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69396153da34832499e80d531dfd4be0)