### PR TITLE
Fix admin user list timeout caused by full queryset evaluation

### DIFF
--- a/touchtechnology/common/sites.py
+++ b/touchtechnology/common/sites.py
@@ -280,7 +280,7 @@ class Application(object):
 
             # If permission is denied, return the response. May already have
             # thrown an exception by now.
-            if not queryset and has_permission is not None:
+            if has_permission is not None and not queryset.exists():
                 return has_permission
 
         if extra_context is None:
@@ -613,7 +613,7 @@ class Application(object):
 
             # If permission is denied, return the response. May already have
             # thrown an exception by now.
-            if not queryset and has_permission is not None:
+            if has_permission is not None and not queryset.exists():
                 return has_permission
 
             queryset = get_objects_for_user(


### PR DESCRIPTION
## Summary

- Fix `SystemExit: 1` (gunicorn worker timeout) on `/admin/auth/user/` caused by `generic_list` and `generic_formset` evaluating the entire queryset into memory during permission checks
- The condition `if not queryset and has_permission is not None` called `QuerySet.__bool__()` first, loading all rows even when `has_permission` was `None` (user has permission) — making the check always `False` but always expensive
- Swap condition order to short-circuit on `has_permission is not None` first, and use `.exists()` for a lightweight `SELECT 1 ... LIMIT 1` when the queryset does need checking

## Test plan

- [x] `tox -e dj52-py313 -- touchtechnology.common` — 97 tests pass
- [x] `tox -e dj52-py313 -- touchtechnology.admin` — 17 tests pass
- [x] Verify on production that `/admin/auth/user/` loads without timeout