### PR TITLE
Refactor YouTube live stream sync to async Celery task

### DIFF
--- a/tests/vitriolic/__init__.py
+++ b/tests/vitriolic/__init__.py
@@ -1,0 +1,11 @@
+from celery import Celery
+
+# A minimal Celery app is configured here so tasks (including ``shared_task``)
+# resolve against Django settings. The test suite sets
+# ``CELERY_TASK_ALWAYS_EAGER`` which makes ``apply_async`` run inline instead of
+# attempting to enqueue against a real broker.
+app = Celery("vitriolic")
+app.config_from_object("django.conf:settings", namespace="CELERY")
+app.autodiscover_tasks()
+
+__all__ = ("app",)

--- a/tests/vitriolic/settings.py
+++ b/tests/vitriolic/settings.py
@@ -182,6 +182,12 @@ GOOGLE_OAUTH2_CLIENT_ID = ""
 GOOGLE_OAUTH2_CLIENT_SECRET = ""
 
 
+# Run Celery tasks inline during the test suite so they execute synchronously
+# against the same database/transactional context as the calling code.
+CELERY_TASK_ALWAYS_EAGER = True
+CELERY_TASK_EAGER_PROPAGATES = True
+
+
 # Logging setup. Adjust handlers as required.
 
 LOGGING = {

--- a/tournamentcontrol/competition/admin.py
+++ b/tournamentcontrol/competition/admin.py
@@ -3,6 +3,7 @@ import collections
 import functools
 import logging
 import operator
+from zoneinfo import ZoneInfo
 
 from django.apps import apps
 from django.conf import settings
@@ -1690,13 +1691,20 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
             )
             return self.redirect(redirect_url)
 
+        if match.get_datetime(ZoneInfo("UTC")) is None:
+            messages.error(
+                request,
+                _("Cannot resync a match without a scheduled date and time."),
+            )
+            return self.redirect(redirect_url)
+
         sync_live_stream.s(
             match.pk, base_url=request.build_absolute_uri("/").rstrip("/")
         ).apply_async()
 
         messages.success(
             request,
-            _("YouTube live stream details resynced from current match data."),
+            _("YouTube live stream resync has been queued."),
         )
         return self.redirect(redirect_url)
 

--- a/tournamentcontrol/competition/admin.py
+++ b/tournamentcontrol/competition/admin.py
@@ -1625,9 +1625,14 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
             # we can't interact with the YouTube API without them.
             if not (season.live_stream_client_id and season.live_stream_client_secret):
                 return None
-            # Only enqueue when there's something to insert/update/delete.
-            if not obj.live_stream and not obj.external_identifier:
-                return None
+            # An existing broadcast always needs syncing (update or delete). For
+            # insert/update we additionally need a scheduled datetime, otherwise
+            # the task would just no-op after rendering templates.
+            if not obj.external_identifier:
+                if not obj.live_stream:
+                    return None
+                if obj.get_datetime(ZoneInfo("UTC")) is None:
+                    return None
             sync_live_stream.s(obj.pk, base_url=base_url).apply_async()
             return None
 

--- a/tournamentcontrol/competition/admin.py
+++ b/tournamentcontrol/competition/admin.py
@@ -3,9 +3,7 @@ import collections
 import functools
 import logging
 import operator
-from zoneinfo import ZoneInfo
 
-from dateutil.relativedelta import relativedelta
 from django.apps import apps
 from django.conf import settings
 from django.contrib import messages
@@ -19,9 +17,8 @@ from django.http import (
     HttpResponseRedirect,
 )
 from django.shortcuts import get_object_or_404
-from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
-from django.urls import NoReverseMatch, include, path, re_path, reverse
+from django.urls import include, path, re_path, reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _, ngettext
 from googleapiclient.errors import HttpError
@@ -106,7 +103,7 @@ from tournamentcontrol.competition.sites import CompetitionAdminMixin
 from tournamentcontrol.competition.tasks import (
     generate_pdf_grid,
     generate_pdf_scorecards,
-    set_youtube_thumbnail,
+    sync_live_stream,
 )
 from tournamentcontrol.competition.utils import (
     FauxQueryset,
@@ -1604,91 +1601,6 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
         messages.success(request, _("Your draw has been undone."))
         return self.redirect(division.urls["edit"])
 
-    @staticmethod
-    def _build_live_stream_body(request, match):
-        """Render title/description templates and build the YouTube broadcast body.
-
-        Returns the body dict, or ``None`` if the match lacks a scheduled start time.
-        """
-        stage = match.stage
-        division = stage.division
-        season = division.season
-        competition = season.competition
-
-        match_url = None
-        if match.pk is not None:
-            try:
-                match_url = request.build_absolute_uri(
-                    reverse(
-                        "competition:match-video",
-                        kwargs={
-                            "competition": competition.slug,
-                            "season": season.slug,
-                            "division": division.slug,
-                            "match": match.pk,
-                        },
-                    )
-                )
-            except NoReverseMatch:
-                # Public competition site not mounted in this project; omit the URL.
-                match_url = None
-
-        template_context = {
-            "match": match,
-            "competition": competition,
-            "season": season,
-            "division": division,
-            "stage": stage,
-            "match_url": match_url,
-        }
-
-        title_templates = [
-            f"tournamentcontrol/competition/{stage.slug}/{division.slug}/{season.slug}/{competition.slug}/match/live_stream/title.txt",
-            f"tournamentcontrol/competition/{stage.slug}/{division.slug}/{season.slug}/match/live_stream/title.txt",
-            f"tournamentcontrol/competition/{stage.slug}/{division.slug}/match/live_stream/title.txt",
-            f"tournamentcontrol/competition/{stage.slug}/match/live_stream/title.txt",
-            "tournamentcontrol/competition/match/live_stream/title.txt",
-        ]
-        title = render_to_string(title_templates, template_context, request).strip()
-
-        description_templates = [
-            f"tournamentcontrol/competition/{stage.slug}/{division.slug}/{season.slug}/{competition.slug}/match/live_stream/description.txt",
-            f"tournamentcontrol/competition/{stage.slug}/{division.slug}/{season.slug}/match/live_stream/description.txt",
-            f"tournamentcontrol/competition/{stage.slug}/{division.slug}/match/live_stream/description.txt",
-            f"tournamentcontrol/competition/{stage.slug}/match/live_stream/description.txt",
-            "tournamentcontrol/competition/match/live_stream/description.txt",
-        ]
-        description = render_to_string(
-            description_templates, template_context, request
-        ).strip()
-
-        start_time = match.get_datetime(ZoneInfo("UTC"))
-        if start_time is None:
-            return None
-
-        stop_time = start_time + relativedelta(minutes=50)  # FIXME: hard coded
-
-        return {
-            "snippet": {
-                "title": title,
-                "description": description,
-                "scheduledStartTime": start_time.isoformat(),
-                "scheduledEndTime": stop_time.isoformat(),
-            },
-            "status": {
-                "privacyStatus": season.live_stream_privacy,
-                "selfDeclaredMadeForKids": False,
-            },
-            "contentDetails": {
-                "enableAutoStart": False,
-                "enableAutoStop": False,
-                "monitorStream": {
-                    "broadcastStreamDelayMs": 0,
-                    "enableMonitorStream": True,
-                },
-            },
-        }
-
     @competition_by_pk_m
     @staff_login_required_m
     def edit_match(
@@ -1705,83 +1617,15 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
         if match is None:
             match = Match(stage=stage, include_in_ladder=stage.keep_ladder)
 
-        def pre_save_callback(obj: Match):
-            # Check if YouTube credentials are configured before attempting anything else,
+        base_url = request.build_absolute_uri("/").rstrip("/")
+
+        def post_save_callback(obj: Match):
+            # Check if YouTube credentials are configured before queuing anything,
             # we can't interact with the YouTube API without them.
             if not (season.live_stream_client_id and season.live_stream_client_secret):
-                return obj
-
-            body = self._build_live_stream_body(request, obj)
-            # New matches without a scheduled date/time cannot be synced yet.
-            if body is None:
-                return
-
-            try:
-                if obj.external_identifier:
-                    # If we have disabled live-streaming where it was previously
-                    # enabled, we need to remove it using the YouTube API.
-                    if not obj.live_stream:
-                        video_id = obj.external_identifier
-                        season.youtube.liveBroadcasts().delete(id=video_id).execute()
-                        if obj.videos is not None:
-                            obj.videos.remove(f"https://youtu.be/{video_id}")
-                        if not obj.videos:
-                            obj.videos = None
-                        obj.external_identifier = None
-                        log.info("YouTube video %(id)r deleted", video_id)
-                        return
-
-                    # Alternatively we're making sure the representation on the backend
-                    # is consistent with the current status.
-                    else:
-                        body["id"] = obj.external_identifier
-                        broadcast = (
-                            season.youtube.liveBroadcasts()
-                            .update(part="snippet,status,contentDetails", body=body)
-                            .execute()
-                        )
-                        set_youtube_thumbnail.s(obj.pk).apply_async(countdown=10)
-                        log.info("YouTube video %(id)r updated", broadcast)
-
-                # If we have enabled live-streaming, but don't have an external id, we
-                # need to create an event with the YouTube API and store the external
-                # id.
-                elif obj.live_stream:
-                    broadcast = (
-                        season.youtube.liveBroadcasts()
-                        .insert(
-                            part="id,snippet,status,contentDetails",
-                            body=body,
-                        )
-                        .execute()
-                    )
-                    obj.external_identifier = broadcast["id"]
-                    set_youtube_thumbnail.s(obj.pk).apply_async(countdown=10)
-                    video_link = f"https://youtu.be/{obj.external_identifier}"
-                    obj.videos = (
-                        [video_link]
-                        if obj.videos is None
-                        else obj.videos.append(video_link)
-                    )
-                    log.info("YouTube video %(id)r inserted", broadcast)
-
-                # We need to bind to a liveStream resource. This is only supported on
-                # a Ground, not a Venue. Only attempt binding if external_identifier exists.
-                if obj.external_identifier and obj.play_at.ground.external_identifier:
-                    bind = (
-                        season.youtube.liveBroadcasts()
-                        .bind(
-                            part="id,snippet,contentDetails,status",
-                            id=obj.external_identifier,
-                            streamId=obj.play_at.ground.external_identifier,
-                        )
-                        .execute()
-                    )
-                    obj.live_stream_bind = bind["contentDetails"].get("boundStreamId")
-
-            except HttpError as exc:
-                messages.error(request, exc.reason)
-                return self.redirect(".")
+                return None
+            sync_live_stream.s(obj.pk, base_url=base_url).apply_async()
+            return None
 
         return self.generic_edit(
             request,
@@ -1792,7 +1636,7 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
             post_save_redirect=self.redirect(
                 request.GET.get("next") or stage.urls["edit"]
             ),
-            pre_save_callback=pre_save_callback if season.live_stream else lambda o: o,
+            post_save_callback=post_save_callback if season.live_stream else lambda o: None,
             permission_required=True,
             extra_context=extra_context,
         )
@@ -1846,42 +1690,9 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
             )
             return self.redirect(redirect_url)
 
-        body = self._build_live_stream_body(request, match)
-        if body is None:
-            messages.error(
-                request,
-                _("Cannot resync a match without a scheduled date and time."),
-            )
-            return self.redirect(redirect_url)
-
-        body["id"] = match.external_identifier
-        try:
-            broadcast = (
-                season.youtube.liveBroadcasts()
-                .update(part="snippet,status,contentDetails", body=body)
-                .execute()
-            )
-            log.info("YouTube video %(id)r resynced", broadcast)
-
-            if match.play_at and match.play_at.ground and match.play_at.ground.external_identifier:
-                bind = (
-                    season.youtube.liveBroadcasts()
-                    .bind(
-                        part="id,snippet,contentDetails,status",
-                        id=match.external_identifier,
-                        streamId=match.play_at.ground.external_identifier,
-                    )
-                    .execute()
-                )
-                bound_stream = bind["contentDetails"].get("boundStreamId")
-                if match.live_stream_bind != bound_stream:
-                    match.live_stream_bind = bound_stream
-                    match.save(update_fields=["live_stream_bind"])
-
-            set_youtube_thumbnail.s(match.pk).apply_async(countdown=10)
-        except HttpError as exc:
-            messages.error(request, exc.reason)
-            return self.redirect(redirect_url)
+        sync_live_stream.s(
+            match.pk, base_url=request.build_absolute_uri("/").rstrip("/")
+        ).apply_async()
 
         messages.success(
             request,

--- a/tournamentcontrol/competition/admin.py
+++ b/tournamentcontrol/competition/admin.py
@@ -1625,6 +1625,9 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
             # we can't interact with the YouTube API without them.
             if not (season.live_stream_client_id and season.live_stream_client_secret):
                 return None
+            # Only enqueue when there's something to insert/update/delete.
+            if not obj.live_stream and not obj.external_identifier:
+                return None
             sync_live_stream.s(obj.pk, base_url=base_url).apply_async()
             return None
 

--- a/tournamentcontrol/competition/tasks.py
+++ b/tournamentcontrol/competition/tasks.py
@@ -173,11 +173,16 @@ def _get_ground(place):
 
 
 def _apply_sync(match, season, body):
-    """Apply a single insert/update/delete + bind cycle against YouTube."""
+    """Apply a single insert/update/delete + bind cycle against YouTube.
+
+    ``body`` may be ``None`` for the delete path, which doesn't need a rendered
+    broadcast body.
+    """
+    youtube = season.youtube
     if match.external_identifier:
         if not match.live_stream:
             video_id = match.external_identifier
-            season.youtube.liveBroadcasts().delete(id=video_id).execute()
+            youtube.liveBroadcasts().delete(id=video_id).execute()
             videos = list(match.videos or [])
             link = f"https://youtu.be/{video_id}"
             if link in videos:
@@ -192,14 +197,14 @@ def _apply_sync(match, season, body):
             return
 
         body["id"] = match.external_identifier
-        season.youtube.liveBroadcasts().update(
+        youtube.liveBroadcasts().update(
             part="snippet,status,contentDetails", body=body
         ).execute()
         logger.info("YouTube video %r updated", match.external_identifier)
         set_youtube_thumbnail.s(match.pk).apply_async(countdown=10)
     elif match.live_stream:
         broadcast = (
-            season.youtube.liveBroadcasts()
+            youtube.liveBroadcasts()
             .insert(part="id,snippet,status,contentDetails", body=body)
             .execute()
         )
@@ -215,7 +220,7 @@ def _apply_sync(match, season, body):
     ground = _get_ground(match.play_at)
     if match.external_identifier and ground and ground.external_identifier:
         bind = (
-            season.youtube.liveBroadcasts()
+            youtube.liveBroadcasts()
             .bind(
                 part="id,snippet,contentDetails,status",
                 id=match.external_identifier,
@@ -245,6 +250,14 @@ def sync_live_stream(match_pk, base_url=None):
     season = match.stage.division.season
 
     if not (season.live_stream_client_id and season.live_stream_client_secret):
+        return
+
+    if match.external_identifier and not match.live_stream:
+        try:
+            _apply_sync(match, season, None)
+        except HttpError as exc:
+            logger.error("YouTube API error syncing match %s: %s", match_pk, exc)
+            raise
         return
 
     for short in (False, True):

--- a/tournamentcontrol/competition/tasks.py
+++ b/tournamentcontrol/competition/tasks.py
@@ -249,9 +249,14 @@ def sync_live_stream(match_pk, base_url=None):
     Competition, and Stage where set) so a recoverable failure remains
     non-fatal and the broadcast can still be created.
     """
-    match = Match.objects.select_related(
-        "stage__division__season__competition",
-    ).get(pk=match_pk)
+    try:
+        match = Match.objects.select_related(
+            "stage__division__season__competition",
+        ).get(pk=match_pk)
+    except Match.DoesNotExist:
+        # Match was deleted between enqueuing and execution; nothing to sync.
+        logger.info("sync_live_stream skipped: match %s no longer exists", match_pk)
+        return
     season = match.stage.division.season
 
     if not (season.live_stream_client_id and season.live_stream_client_secret):

--- a/tournamentcontrol/competition/tasks.py
+++ b/tournamentcontrol/competition/tasks.py
@@ -149,10 +149,7 @@ def _is_title_too_long(exc):
     """Return True when an HttpError indicates an exceeded title length."""
     content = getattr(exc, "content", b"") or b""
     if isinstance(content, (bytes, bytearray)):
-        try:
-            content = content.decode("utf-8", errors="replace")
-        except Exception:
-            content = ""
+        content = bytes(content).decode("utf-8", errors="replace")
     needle = str(content).lower()
     if "title" not in needle:
         return False

--- a/tournamentcontrol/competition/tasks.py
+++ b/tournamentcontrol/competition/tasks.py
@@ -17,6 +17,11 @@ from tournamentcontrol.competition.utils import (
 
 logger = logging.getLogger(__name__)
 
+# YouTube broadcast duration. A match window covers warm-up, play, and a
+# trailing buffer; tighten or widen here if competitions need a different
+# default. Per-season overrides would belong on the Season model.
+LIVE_STREAM_DURATION_MINUTES = 50
+
 
 class _ShortTitle:
     """Substitute ``short_title`` for the rendered name of a SitemapNodeBase.
@@ -116,7 +121,7 @@ def build_live_stream_body(match, base_url=None, short=False):
     if start_time is None:
         return None
 
-    stop_time = start_time + relativedelta(minutes=50)  # FIXME: hard coded
+    stop_time = start_time + relativedelta(minutes=LIVE_STREAM_DURATION_MINUTES)
 
     return {
         "snippet": {
@@ -251,6 +256,9 @@ def sync_live_stream(match_pk, base_url=None):
 
     if not (season.live_stream_client_id and season.live_stream_client_secret):
         return
+
+    if not match.live_stream and not match.external_identifier:
+        return  # Nothing to insert, update, or delete.
 
     if match.external_identifier and not match.live_stream:
         try:

--- a/tournamentcontrol/competition/tasks.py
+++ b/tournamentcontrol/competition/tasks.py
@@ -1,14 +1,250 @@
 import base64
+import logging
+from zoneinfo import ZoneInfo
 
-import requests
 from celery import shared_task
-from googleapiclient.http import MediaInMemoryUpload
+from dateutil.relativedelta import relativedelta
+from django.template.loader import render_to_string
+from django.urls import NoReverseMatch, reverse
+from googleapiclient.errors import HttpError
 
 from tournamentcontrol.competition.models import Match, Stage
 from tournamentcontrol.competition.utils import (
     generate_fixture_grid,
     generate_scorecards,
 )
+
+logger = logging.getLogger(__name__)
+
+
+YOUTUBE_TITLE_MAX_LENGTH = 100
+
+
+class _ShortTitle:
+    """Wrap a SitemapNodeBase so ``str()`` returns ``short_title`` (or ``title``)."""
+
+    def __init__(self, obj):
+        self.__dict__["_obj"] = obj
+
+    def __str__(self):
+        if self._obj is None:
+            return ""
+        return self._obj.short_title or self._obj.title
+
+    def __getattr__(self, name):
+        return getattr(self._obj, name)
+
+
+def build_live_stream_body(match, base_url=None, short=False):
+    """Render title/description templates and build the YouTube broadcast body.
+
+    Returns the body dict, or ``None`` if the match lacks a scheduled start time.
+
+    When ``short`` is true, ``short_title`` is substituted for ``title`` on
+    Competition/Season/Division/Stage in the rendered title and description.
+    """
+    stage = match.stage
+    division = stage.division
+    season = division.season
+    competition = season.competition
+
+    if short:
+        ctx_division = _ShortTitle(division)
+        ctx_season = _ShortTitle(season)
+        ctx_competition = _ShortTitle(competition)
+        ctx_stage = _ShortTitle(stage)
+    else:
+        ctx_division = division
+        ctx_season = season
+        ctx_competition = competition
+        ctx_stage = stage
+
+    match_url = None
+    if base_url and match.pk is not None:
+        try:
+            relative = reverse(
+                "competition:match-video",
+                kwargs={
+                    "competition": competition.slug,
+                    "season": season.slug,
+                    "division": division.slug,
+                    "match": match.pk,
+                },
+            )
+            match_url = base_url.rstrip("/") + relative
+        except NoReverseMatch:
+            match_url = None
+
+    template_context = {
+        "match": match,
+        "competition": ctx_competition,
+        "season": ctx_season,
+        "division": ctx_division,
+        "stage": ctx_stage,
+        "match_url": match_url,
+    }
+
+    title_templates = [
+        f"tournamentcontrol/competition/{stage.slug}/{division.slug}/{season.slug}/{competition.slug}/match/live_stream/title.txt",
+        f"tournamentcontrol/competition/{stage.slug}/{division.slug}/{season.slug}/match/live_stream/title.txt",
+        f"tournamentcontrol/competition/{stage.slug}/{division.slug}/match/live_stream/title.txt",
+        f"tournamentcontrol/competition/{stage.slug}/match/live_stream/title.txt",
+        "tournamentcontrol/competition/match/live_stream/title.txt",
+    ]
+    title = render_to_string(title_templates, template_context).strip()
+
+    description_templates = [
+        f"tournamentcontrol/competition/{stage.slug}/{division.slug}/{season.slug}/{competition.slug}/match/live_stream/description.txt",
+        f"tournamentcontrol/competition/{stage.slug}/{division.slug}/{season.slug}/match/live_stream/description.txt",
+        f"tournamentcontrol/competition/{stage.slug}/{division.slug}/match/live_stream/description.txt",
+        f"tournamentcontrol/competition/{stage.slug}/match/live_stream/description.txt",
+        "tournamentcontrol/competition/match/live_stream/description.txt",
+    ]
+    description = render_to_string(description_templates, template_context).strip()
+
+    start_time = match.get_datetime(ZoneInfo("UTC"))
+    if start_time is None:
+        return None
+
+    stop_time = start_time + relativedelta(minutes=50)  # FIXME: hard coded
+
+    return {
+        "snippet": {
+            "title": title,
+            "description": description,
+            "scheduledStartTime": start_time.isoformat(),
+            "scheduledEndTime": stop_time.isoformat(),
+        },
+        "status": {
+            "privacyStatus": season.live_stream_privacy,
+            "selfDeclaredMadeForKids": False,
+        },
+        "contentDetails": {
+            "enableAutoStart": False,
+            "enableAutoStop": False,
+            "monitorStream": {
+                "broadcastStreamDelayMs": 0,
+                "enableMonitorStream": True,
+            },
+        },
+    }
+
+
+def _is_title_too_long(exc):
+    """Return True when an HttpError indicates an exceeded title length."""
+    content = getattr(exc, "content", b"") or b""
+    if isinstance(content, (bytes, bytearray)):
+        try:
+            content = content.decode("utf-8", errors="replace")
+        except Exception:
+            content = ""
+    needle = str(content).lower()
+    if "title" not in needle:
+        return False
+    return any(
+        marker in needle
+        for marker in ("too long", "maxlength", "max length", "invalidvalue")
+    )
+
+
+def _get_ground(place):
+    """Return the Ground subclass instance for ``place``, or ``None``."""
+    if place is None:
+        return None
+    try:
+        return place.ground
+    except Exception:
+        return None
+
+
+def _apply_sync(match, season, body):
+    """Apply a single insert/update/delete + bind cycle against YouTube."""
+    if match.external_identifier:
+        if not match.live_stream:
+            video_id = match.external_identifier
+            season.youtube.liveBroadcasts().delete(id=video_id).execute()
+            videos = list(match.videos or [])
+            link = f"https://youtu.be/{video_id}"
+            if link in videos:
+                videos.remove(link)
+            match.external_identifier = None
+            match.videos = videos or None
+            match.save(update_fields=["external_identifier", "videos"])
+            logger.info("YouTube video %r deleted", video_id)
+            return
+
+        body["id"] = match.external_identifier
+        season.youtube.liveBroadcasts().update(
+            part="snippet,status,contentDetails", body=body
+        ).execute()
+        logger.info("YouTube video %r updated", match.external_identifier)
+        set_youtube_thumbnail.s(match.pk).apply_async(countdown=10)
+    elif match.live_stream:
+        broadcast = (
+            season.youtube.liveBroadcasts()
+            .insert(part="id,snippet,status,contentDetails", body=body)
+            .execute()
+        )
+        match.external_identifier = broadcast["id"]
+        link = f"https://youtu.be/{match.external_identifier}"
+        videos = list(match.videos or [])
+        videos.append(link)
+        match.videos = videos
+        match.save(update_fields=["external_identifier", "videos"])
+        logger.info("YouTube video %r inserted", match.external_identifier)
+        set_youtube_thumbnail.s(match.pk).apply_async(countdown=10)
+
+    ground = _get_ground(match.play_at)
+    if match.external_identifier and ground and ground.external_identifier:
+        bind = (
+            season.youtube.liveBroadcasts()
+            .bind(
+                part="id,snippet,contentDetails,status",
+                id=match.external_identifier,
+                streamId=ground.external_identifier,
+            )
+            .execute()
+        )
+        bound = bind["contentDetails"].get("boundStreamId")
+        if bound != match.live_stream_bind:
+            match.live_stream_bind = bound
+            match.save(update_fields=["live_stream_bind"])
+
+
+@shared_task
+def sync_live_stream(match_pk, base_url=None):
+    """Synchronize a match with its YouTube broadcast.
+
+    Creates, updates, deletes, and binds the live broadcast as required by the
+    current state of the match. On a YouTube API title-length error, retries
+    once with shortened titles (using ``short_title`` on Division, Season,
+    Competition, and Stage where set) so a recoverable failure remains
+    non-fatal and the broadcast can still be created.
+    """
+    match = Match.objects.select_related(
+        "stage__division__season__competition",
+    ).get(pk=match_pk)
+    season = match.stage.division.season
+
+    if not (season.live_stream_client_id and season.live_stream_client_secret):
+        return
+
+    for short in (False, True):
+        body = build_live_stream_body(match, base_url=base_url, short=short)
+        if body is None:
+            return  # No scheduled time
+        try:
+            _apply_sync(match, season, body)
+            return
+        except HttpError as exc:
+            if not short and _is_title_too_long(exc):
+                logger.warning(
+                    "YouTube rejected match %s title length, retrying with short titles",
+                    match_pk,
+                )
+                continue
+            logger.error("YouTube API error syncing match %s: %s", match_pk, exc)
+            raise
 
 
 @shared_task

--- a/tournamentcontrol/competition/tasks.py
+++ b/tournamentcontrol/competition/tasks.py
@@ -4,6 +4,7 @@ from zoneinfo import ZoneInfo
 
 from celery import shared_task
 from dateutil.relativedelta import relativedelta
+from django.core.exceptions import ObjectDoesNotExist
 from django.template.loader import render_to_string
 from django.urls import NoReverseMatch, reverse
 from googleapiclient.errors import HttpError
@@ -17,16 +18,25 @@ from tournamentcontrol.competition.utils import (
 logger = logging.getLogger(__name__)
 
 
-YOUTUBE_TITLE_MAX_LENGTH = 100
-
-
 class _ShortTitle:
-    """Wrap a SitemapNodeBase so ``str()`` returns ``short_title`` (or ``title``)."""
+    """Substitute ``short_title`` for the rendered name of a SitemapNodeBase.
+
+    Both ``str(obj)`` and attribute access via ``obj.title`` return the short
+    form when set, falling back to ``title``. All other attributes are
+    forwarded to the wrapped object so templates can still resolve fields
+    like ``slug`` or ``short_title`` directly.
+    """
 
     def __init__(self, obj):
         self.__dict__["_obj"] = obj
 
     def __str__(self):
+        if self._obj is None:
+            return ""
+        return self._obj.short_title or self._obj.title
+
+    @property
+    def title(self):
         if self._obj is None:
             return ""
         return self._obj.short_title or self._obj.title
@@ -148,12 +158,17 @@ def _is_title_too_long(exc):
 
 
 def _get_ground(place):
-    """Return the Ground subclass instance for ``place``, or ``None``."""
+    """Return the Ground subclass instance for ``place``, or ``None``.
+
+    ``Place`` is the parent of ``Ground`` via multi-table inheritance, so
+    accessing ``place.ground`` raises ``Ground.DoesNotExist`` (a subclass of
+    ``ObjectDoesNotExist``) when the ``Place`` isn't actually a ``Ground``.
+    """
     if place is None:
         return None
     try:
         return place.ground
-    except Exception:
+    except (AttributeError, ObjectDoesNotExist):
         return None
 
 
@@ -169,7 +184,10 @@ def _apply_sync(match, season, body):
                 videos.remove(link)
             match.external_identifier = None
             match.videos = videos or None
-            match.save(update_fields=["external_identifier", "videos"])
+            match.live_stream_bind = None
+            match.save(
+                update_fields=["external_identifier", "videos", "live_stream_bind"]
+            )
             logger.info("YouTube video %r deleted", video_id)
             return
 

--- a/tournamentcontrol/competition/tasks.py
+++ b/tournamentcontrol/competition/tasks.py
@@ -74,7 +74,9 @@ def build_live_stream_body(match, base_url=None, short=False):
         ctx_competition = competition
         ctx_stage = stage
 
-    match_url = None
+    # Default to an empty string rather than ``None`` so a missing URL doesn't
+    # render as the literal "None" in the YouTube description template.
+    match_url = ""
     if base_url and match.pk is not None:
         try:
             relative = reverse(
@@ -88,7 +90,7 @@ def build_live_stream_body(match, base_url=None, short=False):
             )
             match_url = base_url.rstrip("/") + relative
         except NoReverseMatch:
-            match_url = None
+            match_url = ""
 
     template_context = {
         "match": match,

--- a/tournamentcontrol/competition/tests/test_competition_admin.py
+++ b/tournamentcontrol/competition/tests/test_competition_admin.py
@@ -2198,7 +2198,7 @@ class BackendTests(MessagesTestMixin, TestCase):
         self.post(add_match.url_name, *add_match.args, data=data)
         self.response_302()
 
-    @patch("tournamentcontrol.competition.admin.set_youtube_thumbnail")
+    @patch("tournamentcontrol.competition.tasks.set_youtube_thumbnail")
     @patch("tournamentcontrol.competition.models.Season.youtube", new_callable=PropertyMock)
     def test_resync_live_stream_sends_unescaped_apostrophes(
         self, mock_youtube_prop, mock_thumbnail

--- a/tournamentcontrol/competition/tests/test_live_stream_tasks.py
+++ b/tournamentcontrol/competition/tests/test_live_stream_tasks.py
@@ -7,6 +7,8 @@ from unittest import mock
 from zoneinfo import ZoneInfo
 
 from django.template import Context, Template
+from django.test import override_settings
+from django.urls import NoReverseMatch
 from googleapiclient.errors import HttpError
 from test_plus import TestCase
 
@@ -49,6 +51,7 @@ class IsTitleTooLongTests(TestCase):
         self.assertEqual(False, _is_title_too_long(exc))
 
 
+@override_settings(ROOT_URLCONF="tournamentcontrol.competition.tests.urls")
 class BuildLiveStreamBodyShortTitleTests(TestCase):
     """Verify ``short=True`` swaps in ``short_title`` for the templated names."""
 
@@ -104,6 +107,28 @@ class BuildLiveStreamBodyShortTitleTests(TestCase):
         body = build_live_stream_body(self.match, short=True)
         title = body["snippet"]["title"]
         self.assertIn("Mens Open Division Premier Tier", title)
+
+    def test_base_url_renders_absolute_match_url_in_description(self):
+        """``base_url`` should be combined with the reversed match-video URL."""
+        body = build_live_stream_body(
+            self.match, base_url="https://example.com/"
+        )
+        description = body["snippet"]["description"]
+        self.assertIn("https://example.com/", description)
+        self.assertIn(f"match:{self.match.pk}/video/", description)
+
+    @mock.patch("tournamentcontrol.competition.tasks.reverse")
+    def test_no_reverse_match_renders_description_without_match_url(
+        self, mock_reverse
+    ):
+        """A NoReverseMatch should leave ``match_url`` empty, not crash."""
+        mock_reverse.side_effect = NoReverseMatch("no match")
+        body = build_live_stream_body(
+            self.match, base_url="https://example.com/"
+        )
+        # Description still rendered, just without an absolute URL.
+        self.assertIsNotNone(body)
+        self.assertNotIn("https://example.com/", body["snippet"]["description"])
 
     def test_short_form_substitutes_in_title_attribute_access(self):
         """``{{ division.title }}`` should also receive the short form."""

--- a/tournamentcontrol/competition/tests/test_live_stream_tasks.py
+++ b/tournamentcontrol/competition/tests/test_live_stream_tasks.py
@@ -245,6 +245,22 @@ class SyncLiveStreamTaskTests(TestCase):
 
         mock_youtube.liveBroadcasts.assert_not_called()
 
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_returns_quietly_when_match_was_deleted(self, mock_youtube_prop):
+        """A worker picking up a task for a deleted match must not raise."""
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        match_pk = self.match.pk
+        self.match.delete()
+
+        sync_live_stream(match_pk)
+
+        mock_youtube_prop.assert_not_called()
+        mock_youtube.liveBroadcasts.assert_not_called()
+
     @mock.patch("tournamentcontrol.competition.tasks.set_youtube_thumbnail")
     @mock.patch(
         "tournamentcontrol.competition.models.Season.youtube",

--- a/tournamentcontrol/competition/tests/test_live_stream_tasks.py
+++ b/tournamentcontrol/competition/tests/test_live_stream_tasks.py
@@ -280,6 +280,60 @@ class SyncLiveStreamTaskTests(TestCase):
         "tournamentcontrol.competition.models.Season.youtube",
         new_callable=mock.PropertyMock,
     )
+    def test_delete_runs_when_schedule_was_cleared(
+        self, mock_youtube_prop, mock_thumbnail
+    ):
+        """Disabling live_stream still deletes even if the schedule was cleared."""
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        mock_youtube.liveBroadcasts.return_value.delete.return_value.execute.return_value = {}
+
+        self.match.external_identifier = "yt-orphan"
+        self.match.live_stream = False
+        self.match.videos = ["https://youtu.be/yt-orphan"]
+        self.match.datetime = None
+        self.match.date = None
+        self.match.time = None
+        self.match.save()
+
+        sync_live_stream(self.match.pk)
+
+        self.match.refresh_from_db()
+        self.assertEqual(None, self.match.external_identifier)
+        mock_youtube.liveBroadcasts.return_value.delete.assert_called_once_with(
+            id="yt-orphan"
+        )
+
+    @mock.patch("tournamentcontrol.competition.tasks.set_youtube_thumbnail")
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_youtube_client_is_cached_within_apply_sync(
+        self, mock_youtube_prop, mock_thumbnail
+    ):
+        """``season.youtube`` should be resolved once per sync, not per call."""
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        mock_youtube.liveBroadcasts.return_value.insert.return_value.execute.return_value = {
+            "id": "yt-broadcast-cached",
+        }
+        mock_youtube.liveBroadcasts.return_value.bind.return_value.execute.return_value = {
+            "contentDetails": {"boundStreamId": "stream-resource-cached"},
+        }
+
+        self.ground.external_identifier = "stream-resource-cached"
+        self.ground.save()
+
+        sync_live_stream(self.match.pk)
+
+        self.assertEqual(1, mock_youtube_prop.call_count)
+
+    @mock.patch("tournamentcontrol.competition.tasks.set_youtube_thumbnail")
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
     def test_update_calls_youtube_and_schedules_thumbnail(
         self, mock_youtube_prop, mock_thumbnail
     ):

--- a/tournamentcontrol/competition/tests/test_live_stream_tasks.py
+++ b/tournamentcontrol/competition/tests/test_live_stream_tasks.py
@@ -175,6 +175,10 @@ class SyncLiveStreamTaskTests(TestCase):
         self.assertEqual("yt-broadcast-new", self.match.external_identifier)
         self.assertEqual(["https://youtu.be/yt-broadcast-new"], self.match.videos)
         mock_youtube.liveBroadcasts.return_value.insert.assert_called_once()
+        mock_thumbnail.s.assert_called_once_with(self.match.pk)
+        mock_thumbnail.s.return_value.apply_async.assert_called_once_with(
+            countdown=10
+        )
 
     @mock.patch("tournamentcontrol.competition.tasks.set_youtube_thumbnail")
     @mock.patch(
@@ -206,6 +210,10 @@ class SyncLiveStreamTaskTests(TestCase):
         self.assertIn("LS25", retry_title)
         self.assertNotIn(
             "Mens Premier Open Division Top Tier Premier", retry_title
+        )
+        mock_thumbnail.s.assert_called_once_with(self.match.pk)
+        mock_thumbnail.s.return_value.apply_async.assert_called_once_with(
+            countdown=10
         )
 
     @mock.patch("tournamentcontrol.competition.tasks.set_youtube_thumbnail")

--- a/tournamentcontrol/competition/tests/test_live_stream_tasks.py
+++ b/tournamentcontrol/competition/tests/test_live_stream_tasks.py
@@ -6,10 +6,12 @@ from datetime import date, datetime, time
 from unittest import mock
 from zoneinfo import ZoneInfo
 
+from django.template import Context, Template
 from googleapiclient.errors import HttpError
 from test_plus import TestCase
 
 from tournamentcontrol.competition.tasks import (
+    _ShortTitle,
     _is_title_too_long,
     build_live_stream_body,
     sync_live_stream,
@@ -105,10 +107,6 @@ class BuildLiveStreamBodyShortTitleTests(TestCase):
 
     def test_short_form_substitutes_in_title_attribute_access(self):
         """``{{ division.title }}`` should also receive the short form."""
-        from django.template import Context, Template
-
-        from tournamentcontrol.competition.tasks import _ShortTitle
-
         wrapped = _ShortTitle(self.division)
         rendered = Template("{{ d }}|{{ d.title }}|{{ d.slug }}").render(
             Context({"d": wrapped})
@@ -274,6 +272,24 @@ class SyncLiveStreamTaskTests(TestCase):
         mock_youtube.liveBroadcasts.return_value.delete.assert_called_once_with(
             id="yt-existing"
         )
+
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_no_op_returns_without_calling_api(self, mock_youtube_prop):
+        """No external broadcast and live_stream=False should be a fast no-op."""
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        self.match.live_stream = False
+        self.match.external_identifier = None
+        self.match.save()
+
+        sync_live_stream(self.match.pk)
+
+        mock_youtube.liveBroadcasts.assert_not_called()
+        # The youtube property shouldn't be resolved at all in the no-op path.
+        self.assertEqual(0, mock_youtube_prop.call_count)
 
     @mock.patch("tournamentcontrol.competition.tasks.set_youtube_thumbnail")
     @mock.patch(

--- a/tournamentcontrol/competition/tests/test_live_stream_tasks.py
+++ b/tournamentcontrol/competition/tests/test_live_stream_tasks.py
@@ -126,9 +126,19 @@ class BuildLiveStreamBodyShortTitleTests(TestCase):
         body = build_live_stream_body(
             self.match, base_url="https://example.com/"
         )
-        # Description still rendered, just without an absolute URL.
-        self.assertIsNotNone(body)
-        self.assertNotIn("https://example.com/", body["snippet"]["description"])
+        description = body["snippet"]["description"]
+        # No absolute URL leaks through, and the literal "None" never lands in
+        # the description because ``match_url`` defaults to "".
+        self.assertNotIn("https://example.com/", description)
+        self.assertNotIn("None", description)
+        self.assertIn("Full match details are available at", description)
+
+    def test_match_url_defaults_to_empty_string_when_no_base_url(self):
+        """Without ``base_url`` the description renders cleanly (no "None")."""
+        body = build_live_stream_body(self.match)
+        description = body["snippet"]["description"]
+        self.assertNotIn("None", description)
+        self.assertIn("Full match details are available at", description)
 
     def test_short_form_substitutes_in_title_attribute_access(self):
         """``{{ division.title }}`` should also receive the short form."""

--- a/tournamentcontrol/competition/tests/test_live_stream_tasks.py
+++ b/tournamentcontrol/competition/tests/test_live_stream_tasks.py
@@ -103,6 +103,21 @@ class BuildLiveStreamBodyShortTitleTests(TestCase):
         title = body["snippet"]["title"]
         self.assertIn("Mens Open Division Premier Tier", title)
 
+    def test_short_form_substitutes_in_title_attribute_access(self):
+        """``{{ division.title }}`` should also receive the short form."""
+        from django.template import Context, Template
+
+        from tournamentcontrol.competition.tasks import _ShortTitle
+
+        wrapped = _ShortTitle(self.division)
+        rendered = Template("{{ d }}|{{ d.title }}|{{ d.slug }}").render(
+            Context({"d": wrapped})
+        )
+        self.assertEqual(
+            "MOD|MOD|" + self.division.slug,
+            rendered,
+        )
+
 
 class SyncLiveStreamTaskTests(TestCase):
     """Exercise the celery task that synchronises a match with YouTube."""
@@ -247,6 +262,7 @@ class SyncLiveStreamTaskTests(TestCase):
         self.match.external_identifier = "yt-existing"
         self.match.live_stream = False
         self.match.videos = ["https://youtu.be/yt-existing"]
+        self.match.live_stream_bind = "stale-bound-stream"
         self.match.save()
 
         sync_live_stream(self.match.pk)
@@ -254,8 +270,43 @@ class SyncLiveStreamTaskTests(TestCase):
         self.match.refresh_from_db()
         self.assertEqual(None, self.match.external_identifier)
         self.assertEqual(None, self.match.videos)
+        self.assertEqual(None, self.match.live_stream_bind)
         mock_youtube.liveBroadcasts.return_value.delete.assert_called_once_with(
             id="yt-existing"
+        )
+
+    @mock.patch("tournamentcontrol.competition.tasks.set_youtube_thumbnail")
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_update_calls_youtube_and_schedules_thumbnail(
+        self, mock_youtube_prop, mock_thumbnail
+    ):
+        """An existing broadcast is updated and the thumbnail task is scheduled."""
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        mock_youtube.liveBroadcasts.return_value.update.return_value.execute.return_value = {
+            "id": "yt-existing-update",
+        }
+
+        self.match.external_identifier = "yt-existing-update"
+        self.match.live_stream = True
+        self.match.save()
+
+        sync_live_stream(self.match.pk)
+
+        update_call = mock_youtube.liveBroadcasts.return_value.update.call_args
+        self.assertEqual(
+            "snippet,status,contentDetails", update_call.kwargs["part"]
+        )
+        self.assertEqual(
+            "yt-existing-update", update_call.kwargs["body"]["id"]
+        )
+        mock_youtube.liveBroadcasts.return_value.insert.assert_not_called()
+        mock_thumbnail.s.assert_called_once_with(self.match.pk)
+        mock_thumbnail.s.return_value.apply_async.assert_called_once_with(
+            countdown=10
         )
 
     @mock.patch("tournamentcontrol.competition.tasks.set_youtube_thumbnail")

--- a/tournamentcontrol/competition/tests/test_live_stream_tasks.py
+++ b/tournamentcontrol/competition/tests/test_live_stream_tasks.py
@@ -1,0 +1,284 @@
+"""
+Tests for the asynchronous live stream synchronization task.
+"""
+
+from datetime import date, datetime, time
+from unittest import mock
+from zoneinfo import ZoneInfo
+
+from googleapiclient.errors import HttpError
+from test_plus import TestCase
+
+from tournamentcontrol.competition.tasks import (
+    _is_title_too_long,
+    build_live_stream_body,
+    sync_live_stream,
+)
+from tournamentcontrol.competition.tests import factories
+
+
+def _http_error(status, message):
+    resp = mock.Mock(status=status, reason="Bad Request")
+    content = (
+        b'{"error": {"errors": [{"reason": "invalidValue", "message": "'
+        + message.encode()
+        + b'"}], "code": '
+        + str(status).encode()
+        + b', "message": "'
+        + message.encode()
+        + b'"}}'
+    )
+    return HttpError(resp=resp, content=content)
+
+
+class IsTitleTooLongTests(TestCase):
+    """Detect title-length errors from a YouTube HttpError."""
+
+    def test_detects_title_max_length(self):
+        exc = _http_error(400, "title is too long")
+        self.assertEqual(True, _is_title_too_long(exc))
+
+    def test_detects_invalid_value_with_title(self):
+        exc = _http_error(400, "Invalid title value: invalidValue")
+        self.assertEqual(True, _is_title_too_long(exc))
+
+    def test_ignores_unrelated_errors(self):
+        exc = _http_error(403, "quotaExceeded")
+        self.assertEqual(False, _is_title_too_long(exc))
+
+
+class BuildLiveStreamBodyShortTitleTests(TestCase):
+    """Verify ``short=True`` swaps in ``short_title`` for the templated names."""
+
+    def setUp(self):
+        self.season = factories.SeasonFactory.create(
+            title="Premiership Season Two Thousand Twenty Five",
+            short_title="PS25",
+            live_stream_privacy="unlisted",
+        )
+        self.division = factories.DivisionFactory.create(
+            season=self.season,
+            title="Mens Open Division Premier Tier",
+            short_title="MOD",
+        )
+        self.stage = factories.StageFactory.create(
+            division=self.division,
+            title="Quarter Finals Stage",
+            short_title="QF",
+        )
+        self.season.competition.title = "International Touch Championship"
+        self.season.competition.short_title = "ITC"
+        self.season.competition.save()
+
+        self.ground = factories.GroundFactory.create(venue__season=self.season)
+        self.match = factories.MatchFactory.create(
+            stage=self.stage,
+            play_at=self.ground,
+            label="QF1",
+            datetime=datetime(2025, 5, 1, 4, 0, tzinfo=ZoneInfo("UTC")),
+            date=date(2025, 5, 1),
+            time=time(14, 0),
+        )
+
+    def test_long_form_uses_titles(self):
+        body = build_live_stream_body(self.match)
+        title = body["snippet"]["title"]
+        self.assertIn("Mens Open Division Premier Tier", title)
+        self.assertIn("International Touch Championship", title)
+        self.assertIn("Premiership Season Two Thousand Twenty Five", title)
+
+    def test_short_form_uses_short_titles(self):
+        body = build_live_stream_body(self.match, short=True)
+        title = body["snippet"]["title"]
+        self.assertIn("MOD", title)
+        self.assertIn("ITC", title)
+        self.assertIn("PS25", title)
+        self.assertNotIn("Mens Open Division Premier Tier", title)
+        self.assertNotIn("International Touch Championship", title)
+
+    def test_short_form_falls_back_to_title_when_unset(self):
+        self.division.short_title = ""
+        self.division.save()
+        body = build_live_stream_body(self.match, short=True)
+        title = body["snippet"]["title"]
+        self.assertIn("Mens Open Division Premier Tier", title)
+
+
+class SyncLiveStreamTaskTests(TestCase):
+    """Exercise the celery task that synchronises a match with YouTube."""
+
+    def setUp(self):
+        self.season = factories.SeasonFactory.create(
+            title="Long Season Title For Live Streaming Tests",
+            short_title="LS25",
+            live_stream=True,
+            live_stream_project_id="test-project",
+            live_stream_client_id="test-client-id",
+            live_stream_client_secret="test-client-secret",
+            live_stream_privacy="unlisted",
+        )
+        self.division = factories.DivisionFactory.create(
+            season=self.season,
+            title="Mens Premier Open Division Top Tier Premier",
+            short_title="MPO",
+        )
+        self.stage = factories.StageFactory.create(
+            division=self.division,
+            title="Group Stage One",
+            short_title="GS1",
+        )
+        self.ground = factories.GroundFactory.create(
+            venue__season=self.season,
+            external_identifier=None,
+        )
+        self.match = factories.MatchFactory.create(
+            stage=self.stage,
+            play_at=self.ground,
+            label="Round 1",
+            live_stream=True,
+            external_identifier=None,
+            datetime=datetime(2025, 5, 1, 4, 0, tzinfo=ZoneInfo("UTC")),
+            date=date(2025, 5, 1),
+            time=time(14, 0),
+        )
+
+    @mock.patch("tournamentcontrol.competition.tasks.set_youtube_thumbnail")
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_insert_creates_broadcast_and_persists_identifier(
+        self, mock_youtube_prop, mock_thumbnail
+    ):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        mock_youtube.liveBroadcasts.return_value.insert.return_value.execute.return_value = {
+            "id": "yt-broadcast-new",
+        }
+
+        sync_live_stream(self.match.pk)
+
+        self.match.refresh_from_db()
+        self.assertEqual("yt-broadcast-new", self.match.external_identifier)
+        self.assertEqual(["https://youtu.be/yt-broadcast-new"], self.match.videos)
+        mock_youtube.liveBroadcasts.return_value.insert.assert_called_once()
+
+    @mock.patch("tournamentcontrol.competition.tasks.set_youtube_thumbnail")
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_retries_with_short_titles_when_title_too_long(
+        self, mock_youtube_prop, mock_thumbnail
+    ):
+        """A title-length HttpError triggers a retry using ``short_title``."""
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        mock_youtube.liveBroadcasts.return_value.insert.return_value.execute.side_effect = [
+            _http_error(400, "title is too long"),
+            {"id": "yt-broadcast-short"},
+        ]
+
+        sync_live_stream(self.match.pk)
+
+        self.match.refresh_from_db()
+        self.assertEqual("yt-broadcast-short", self.match.external_identifier)
+
+        insert_calls = mock_youtube.liveBroadcasts.return_value.insert.call_args_list
+        self.assertEqual(2, len(insert_calls))
+        first_title = insert_calls[0].kwargs["body"]["snippet"]["title"]
+        retry_title = insert_calls[1].kwargs["body"]["snippet"]["title"]
+        self.assertIn("Mens Premier Open Division Top Tier Premier", first_title)
+        self.assertIn("MPO", retry_title)
+        self.assertIn("LS25", retry_title)
+        self.assertNotIn(
+            "Mens Premier Open Division Top Tier Premier", retry_title
+        )
+
+    @mock.patch("tournamentcontrol.competition.tasks.set_youtube_thumbnail")
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_unrelated_http_error_is_propagated_without_retry(
+        self, mock_youtube_prop, mock_thumbnail
+    ):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        mock_youtube.liveBroadcasts.return_value.insert.return_value.execute.side_effect = (
+            _http_error(403, "quotaExceeded")
+        )
+
+        with self.assertRaises(HttpError):
+            sync_live_stream(self.match.pk)
+
+        self.assertEqual(
+            1,
+            len(mock_youtube.liveBroadcasts.return_value.insert.call_args_list),
+        )
+
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_no_credentials_skips_api(self, mock_youtube_prop):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        self.season.live_stream_client_id = None
+        self.season.live_stream_client_secret = None
+        self.season.save()
+
+        sync_live_stream(self.match.pk)
+
+        mock_youtube.liveBroadcasts.assert_not_called()
+
+    @mock.patch("tournamentcontrol.competition.tasks.set_youtube_thumbnail")
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_delete_clears_external_identifier_when_disabling(
+        self, mock_youtube_prop, mock_thumbnail
+    ):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        mock_youtube.liveBroadcasts.return_value.delete.return_value.execute.return_value = {}
+
+        self.match.external_identifier = "yt-existing"
+        self.match.live_stream = False
+        self.match.videos = ["https://youtu.be/yt-existing"]
+        self.match.save()
+
+        sync_live_stream(self.match.pk)
+
+        self.match.refresh_from_db()
+        self.assertEqual(None, self.match.external_identifier)
+        self.assertEqual(None, self.match.videos)
+        mock_youtube.liveBroadcasts.return_value.delete.assert_called_once_with(
+            id="yt-existing"
+        )
+
+    @mock.patch("tournamentcontrol.competition.tasks.set_youtube_thumbnail")
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_bind_persists_bound_stream_id_when_ground_has_external_id(
+        self, mock_youtube_prop, mock_thumbnail
+    ):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        mock_youtube.liveBroadcasts.return_value.insert.return_value.execute.return_value = {
+            "id": "yt-broadcast-bind",
+        }
+        mock_youtube.liveBroadcasts.return_value.bind.return_value.execute.return_value = {
+            "contentDetails": {"boundStreamId": "stream-resource-1"},
+        }
+
+        self.ground.external_identifier = "stream-resource-1"
+        self.ground.save()
+
+        sync_live_stream(self.match.pk)
+
+        self.match.refresh_from_db()
+        self.assertEqual("stream-resource-1", self.match.live_stream_bind)


### PR DESCRIPTION
## Summary
Extracted YouTube live stream synchronization logic from the admin interface into a dedicated async Celery task, enabling non-blocking broadcast management and improving code maintainability.

## Key Changes

- **New `sync_live_stream` Celery task** (`tasks.py`): Handles all YouTube broadcast operations (create, update, delete, bind) asynchronously with automatic retry on title-length errors using shortened titles
- **Extracted `build_live_stream_body` function**: Generates YouTube broadcast metadata with support for custom title/description templates and optional short-title substitution via new `_ShortTitle` wrapper class
- **Added `_is_title_too_long` helper**: Detects YouTube API title-length errors to enable graceful recovery by retrying with abbreviated titles
- **Refactored admin `edit_match` view**: Replaced synchronous pre-save YouTube API calls with async task queueing via `post_save_callback`
- **Simplified `resync_match_live_stream` action**: Now delegates to the `sync_live_stream` task instead of duplicating API logic
- **Comprehensive test suite** (`test_live_stream_tasks.py`): 284 lines of tests covering title detection, body building, insert/update/delete/bind operations, error handling, and credential validation
- **Celery configuration**: Added minimal app setup and test settings to run tasks eagerly during test execution

## Notable Implementation Details

- Title-length retry mechanism automatically falls back to `short_title` fields on Competition, Season, Division, and Stage when the full title exceeds YouTube's 100-character limit
- `_ShortTitle` wrapper transparently substitutes shortened names in template rendering without modifying the underlying model instances
- Task accepts optional `base_url` parameter for constructing absolute match URLs in broadcast descriptions
- Ground binding only occurs when both match and ground have external identifiers configured
- Credentials validation prevents unnecessary API calls when YouTube integration is not configured

https://claude.ai/code/session_01TJvztBQc3TdWAisduDERrJ