### PR TITLE
Fix N+1 queries on team edit, match detail, and division views

### DIFF
--- a/touchtechnology/admin/templatetags/mvp_tags.py
+++ b/touchtechnology/admin/templatetags/mvp_tags.py
@@ -118,6 +118,7 @@ def related(instance, whitelist=None):
     related = getattr(instance, "_mvp_related", {})
     annotate = getattr(instance, "_mvp_annotate", {})
     select_related = getattr(instance, "_mvp_select_related", {})
+    prefetch_related = getattr(instance, "_mvp_prefetch_related", {})
     only = getattr(instance, "_mvp_only", {})
 
     for name, manager in rel.items():
@@ -129,6 +130,8 @@ def related(instance, whitelist=None):
         else:
             if name in select_related:
                 manager = manager.select_related(*select_related[name])
+            if name in prefetch_related:
+                manager = manager.prefetch_related(*prefetch_related[name])
             if name in annotate:
                 manager = manager.annotate(**annotate[name])
             if name in only:

--- a/tournamentcontrol/competition/models.py
+++ b/tournamentcontrol/competition/models.py
@@ -900,6 +900,7 @@ class Division(
             .select_related(
                 "play_at",
                 "stage__division",
+                "stage_group",
                 "home_team__club",
                 "home_team__division",
                 "away_team__club",
@@ -1321,6 +1322,7 @@ class Stage(AdminUrlMixin, OrderedSitemapNode):
             self.matches.select_related(
                 "play_at",
                 "stage__division",
+                "stage_group",
                 "home_team__club",
                 "home_team__division",
                 "away_team__club",
@@ -1399,6 +1401,7 @@ class StageGroup(AdminUrlMixin, OrderedSitemapNode):
         matches = self.matches.select_related(
             "play_at",
             "stage__division",
+            "stage_group",
             "home_team__club",
             "home_team__division",
             "away_team__club",
@@ -1528,6 +1531,14 @@ class Team(AdminUrlMixin, OrderedSitemapNode):
             raise ValidationError(errors)
 
         return super(Team, self).clean()
+
+    @cached_property
+    def _mvp_select_related(self):
+        return {"people": ["person"]}
+
+    @cached_property
+    def _mvp_prefetch_related(self):
+        return {"people": ["roles"]}
 
     def _get_admin_namespace(self):
         return "admin:fixja:competition:season:division:team"

--- a/tournamentcontrol/competition/templatetags/competition.py
+++ b/tournamentcontrol/competition/templatetags/competition.py
@@ -243,8 +243,16 @@ def preview(match):
         ),
     }
 
-    home_team = match.home_team.people.filter(is_player=True).annotate(**annotate)
-    away_team = match.away_team.people.filter(is_player=True).annotate(**annotate)
+    home_team = (
+        match.home_team.people.filter(is_player=True)
+        .annotate(**annotate)
+        .prefetch_related("person")
+    )
+    away_team = (
+        match.away_team.people.filter(is_player=True)
+        .annotate(**annotate)
+        .prefetch_related("person")
+    )
 
     context = {
         "match": match,

--- a/tournamentcontrol/competition/tests/test_competition_admin.py
+++ b/tournamentcontrol/competition/tests/test_competition_admin.py
@@ -2312,7 +2312,10 @@ class TeamEditViewQueryTests(TestCase):
         cls.empty_team = factories.TeamFactory.create()
         cls.full_team = factories.TeamFactory.create()
         for _ in range(20):
-            factories.TeamAssociationFactory.create(team=cls.full_team)
+            factories.TeamAssociationFactory.create(
+                team=cls.full_team,
+                person=factories.PersonFactory.create(club=cls.full_team.club),
+            )
 
     def test_empty_team_query_count(self):
         edit_team = self.empty_team.url_names["edit"]

--- a/tournamentcontrol/competition/tests/test_competition_admin.py
+++ b/tournamentcontrol/competition/tests/test_competition_admin.py
@@ -2294,3 +2294,40 @@ class BackendTests(MessagesTestMixin, TestCase):
         self.response_302()
 
         mock_youtube.liveBroadcasts.return_value.update.assert_not_called()
+
+
+class TeamEditViewQueryTests(TestCase):
+    """
+    The team edit page in the competition admin renders the team's
+    ``people`` (``TeamAssociation``) list using the ``mvp_list``
+    template tag. Without prefetching, that produces one
+    ``competition_person`` query and one ``competition_teamrole`` query
+    per association. Pin the view's query count so the same upper bound
+    holds whether the team is empty or fully squadded - any per-player
+    scaling trips the large case.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.empty_team = factories.TeamFactory.create()
+        cls.full_team = factories.TeamFactory.create()
+        for _ in range(20):
+            factories.TeamAssociationFactory.create(team=cls.full_team)
+
+    def test_empty_team_query_count(self):
+        edit_team = self.empty_team.url_names["edit"]
+        with self.login(self.superuser):
+            self.assertGoodView(
+                edit_team.url_name,
+                *edit_team.args,
+                test_query_count=25,
+            )
+
+    def test_full_team_query_count(self):
+        edit_team = self.full_team.url_names["edit"]
+        with self.login(self.superuser):
+            self.assertGoodView(
+                edit_team.url_name,
+                *edit_team.args,
+                test_query_count=25,
+            )

--- a/tournamentcontrol/competition/tests/test_competition_site.py
+++ b/tournamentcontrol/competition/tests/test_competition_site.py
@@ -815,3 +815,52 @@ class DivisionViewQueryTests(TestCase):
             self.large_division.slug,
             test_query_count=14,
         )
+
+
+@override_settings(ROOT_URLCONF="tournamentcontrol.competition.tests.urls")
+class MatchDetailViewQueryTests(TestCase):
+    """
+    The public match detail page renders the ``preview`` template tag,
+    which iterates ``TeamAssociation`` rows for both teams and
+    dereferences ``person`` on each one. Without prefetching, that
+    produces one ``competition_person`` query per associated player.
+    Pin the view's query count so the same upper bound holds whether
+    the teams are empty or fully squadded - any per-player scaling
+    trips the large case.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.season = factories.SeasonFactory.create()
+        cls.competition = cls.season.competition
+        cls.division = factories.DivisionFactory.create(season=cls.season)
+        cls.stage = factories.StageFactory.create(division=cls.division)
+
+        # Small: a match with no team associations.
+        cls.small_match = factories.MatchFactory.create(stage=cls.stage)
+
+        # Large: a match where each team has 12 associated players.
+        cls.large_match = factories.MatchFactory.create(stage=cls.stage)
+        for _ in range(12):
+            factories.TeamAssociationFactory.create(team=cls.large_match.home_team)
+            factories.TeamAssociationFactory.create(team=cls.large_match.away_team)
+
+    def test_small_match_query_count(self):
+        self.assertGoodView(
+            "competition:match",
+            self.competition.slug,
+            self.season.slug,
+            self.division.slug,
+            self.small_match.pk,
+            test_query_count=18,
+        )
+
+    def test_large_match_query_count(self):
+        self.assertGoodView(
+            "competition:match",
+            self.competition.slug,
+            self.season.slug,
+            self.division.slug,
+            self.large_match.pk,
+            test_query_count=18,
+        )

--- a/tournamentcontrol/competition/tests/test_competition_site.py
+++ b/tournamentcontrol/competition/tests/test_competition_site.py
@@ -842,8 +842,18 @@ class MatchDetailViewQueryTests(TestCase):
         # Large: a match where each team has 12 associated players.
         cls.large_match = factories.MatchFactory.create(stage=cls.stage)
         for _ in range(12):
-            factories.TeamAssociationFactory.create(team=cls.large_match.home_team)
-            factories.TeamAssociationFactory.create(team=cls.large_match.away_team)
+            factories.TeamAssociationFactory.create(
+                team=cls.large_match.home_team,
+                person=factories.PersonFactory.create(
+                    club=cls.large_match.home_team.club,
+                ),
+            )
+            factories.TeamAssociationFactory.create(
+                team=cls.large_match.away_team,
+                person=factories.PersonFactory.create(
+                    club=cls.large_match.away_team.club,
+                ),
+            )
 
     def test_small_match_query_count(self):
         self.assertGoodView(


### PR DESCRIPTION
## Summary

Three N+1 query patterns reported via Sentry were tracked down to specific querysets used by the affected templates / template tags. Each is fixed by adding the appropriate `select_related` / `prefetch_related` to the queryset that feeds the template, scoped as narrowly as possible.

### #287 — Team edit admin view
Render of `tournamentcontrol/competition/admin/team/edit.html` was issuing one `competition_person` SELECT and one `competition_teamrole` join query per `TeamAssociation` (96 in the captured event).

The `mvp_list` template tag's `related` filter already supports `_mvp_select_related`, so this PR:

- Adds a parallel `_mvp_prefetch_related` hook to `touchtechnology/admin/templatetags/mvp_tags.py:related`.
- Declares both on `Team`: `_mvp_select_related = {"people": ["person"]}` and `_mvp_prefetch_related = {"people": ["roles"]}`.

### #288 — Public match detail page
The `preview` template tag rendered from `match.html` iterated `TeamAssociation` rows and dereferenced `.person` per row (24 queries in the captured event).

The queryset is also annotated with `Sum()` aggregations, which forces a `GROUP BY` and rules out `select_related('person')` (PostgreSQL rejects un-grouped Person columns). Used `prefetch_related('person')` instead — one extra query per team, regardless of squad size.

### #289 — Public division detail page
`Division.matches_by_date` (used by `division.html`) was missing `stage_group` from its `select_related`, causing per-match StageGroup lookups (45 in the captured event). Added `stage_group` here and to the parallel `Stage.matches_by_date` and `StageGroup.matches_by_date` for consistency.

## Regression tests

Added matched-pair query-count tests for the team edit and match detail views, following the existing `DivisionViewQueryTests` pattern: a "small" and a "large" instance share the same `test_query_count` upper bound, so any per-row scaling trips the large case.

- `MatchDetailViewQueryTests` — empty match vs. 12 players each side, both bounded at 18 queries.
- `TeamEditViewQueryTests` — empty team vs. 20 associations, both bounded at 25 queries.

Existing `DivisionViewQueryTests` (already pinned at 14 queries for both small and large divisions) continues to pass.

## Test plan
- [x] `python manage.py test tournamentcontrol.competition` — 283 tests pass
- [x] `python manage.py test touchtechnology` — 160 tests pass
- [x] New `MatchDetailViewQueryTests`, `TeamEditViewQueryTests`, and existing `DivisionViewQueryTests` all pass

Closes #287, closes #288, closes #289.

https://claude.ai/code/session_01NAfaRQpqDZDzHHC8TYmEas

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAfaRQpqDZDzHHC8TYmEas)_