### PR TITLE
Fix pathological query plan in experimental fixtures view

### DIFF
--- a/tournamentcontrol/competition/sites.py
+++ b/tournamentcontrol/competition/sites.py
@@ -1091,6 +1091,14 @@ class CompetitionSite(CompetitionAdminMixin, Application):
             .select_related(None)
             .select_related("play_at", "stage__division", "stage_group")
             .prefetch_related(
+                Prefetch(
+                    "home_team",
+                    queryset=Team.objects.select_related("club", "division"),
+                ),
+                Prefetch(
+                    "away_team",
+                    queryset=Team.objects.select_related("club", "division"),
+                ),
                 "home_team_undecided",
                 "away_team_undecided",
                 "home_team_eval_related",

--- a/tournamentcontrol/competition/sites.py
+++ b/tournamentcontrol/competition/sites.py
@@ -1085,20 +1085,15 @@ class CompetitionSite(CompetitionAdminMixin, Application):
             draw=Sum("draw"),
         )
 
+        team_qs = Team.objects.select_related("club", "division")
         undecided = (
             division.matches.filter(team_needs_progressing)
             .exclude(is_bye=True)
             .select_related(None)
             .select_related("play_at", "stage__division", "stage_group")
             .prefetch_related(
-                Prefetch(
-                    "home_team",
-                    queryset=Team.objects.select_related("club", "division"),
-                ),
-                Prefetch(
-                    "away_team",
-                    queryset=Team.objects.select_related("club", "division"),
-                ),
+                Prefetch("home_team", queryset=team_qs),
+                Prefetch("away_team", queryset=team_qs),
                 "home_team_undecided",
                 "away_team_undecided",
                 "home_team_eval_related",

--- a/tournamentcontrol/competition/sites.py
+++ b/tournamentcontrol/competition/sites.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.sitemaps import views as sitemaps_views
 from django.core.exceptions import ObjectDoesNotExist
-from django.db.models import Case, Count, F, Q, Sum, When
+from django.db.models import Case, Count, F, Prefetch, Q, Sum, When
 from django.http import Http404, HttpResponse, HttpResponseGone
 from django.shortcuts import get_object_or_404
 from django.urls import include, path, re_path, reverse
@@ -961,17 +961,21 @@ class CompetitionSite(CompetitionAdminMixin, Application):
         if not season.enable_experimental_views:
             raise Http404("Experimental views are not enabled for this season.")
 
+        # Keep the base query narrow — matches plus the joins needed for
+        # filtering and ordering only. Wide select_related chains (teams,
+        # clubs, and especially the *_eval_related self-joins back onto
+        # the match table) produced pathological query plans on large
+        # production datasets; the related objects are fetched with a
+        # handful of flat prefetch queries instead.
+        team_qs = Team.objects.select_related("club", "division")
         matches = (
             season.matches.exclude(is_bye=True)
             .filter(stage__division__draft=False)
-            .select_related(
-                "play_at",
-                "stage__division",
-                "stage_group",
-                "home_team__club",
-                "home_team__division",
-                "away_team__club",
-                "away_team__division",
+            .select_related(None)
+            .select_related("play_at", "stage__division", "stage_group")
+            .prefetch_related(
+                Prefetch("home_team", queryset=team_qs),
+                Prefetch("away_team", queryset=team_qs),
                 "home_team_undecided",
                 "away_team_undecided",
                 "home_team_eval_related",
@@ -1084,10 +1088,9 @@ class CompetitionSite(CompetitionAdminMixin, Application):
         undecided = (
             division.matches.filter(team_needs_progressing)
             .exclude(is_bye=True)
-            .select_related(
-                "play_at",
-                "stage__division",
-                "stage_group",
+            .select_related(None)
+            .select_related("play_at", "stage__division", "stage_group")
+            .prefetch_related(
                 "home_team_undecided",
                 "away_team_undecided",
                 "home_team_eval_related",

--- a/tournamentcontrol/competition/templates/tournamentcontrol/competition/team_timeline.html
+++ b/tournamentcontrol/competition/templates/tournamentcontrol/competition/team_timeline.html
@@ -17,11 +17,11 @@
 
 	{% block record %}
 		{% if record.played %}
+			{% blocktrans count counter=record.win|default:0 asvar wins %}{{ counter }} win{% plural %}{{ counter }} wins{% endblocktrans %}
+			{% blocktrans count counter=record.loss|default:0 asvar losses %}{{ counter }} loss{% plural %}{{ counter }} losses{% endblocktrans %}
+			{% blocktrans count counter=record.draw|default:0 asvar draws %}{{ counter }} draw{% plural %}{{ counter }} draws{% endblocktrans %}
 			<p class="team-record">
-				{% blocktrans with played=record.played %}Played {{ played }}:{% endblocktrans %}
-				{% blocktrans count counter=record.win|default:0 %}{{ counter }} win{% plural %}{{ counter }} wins{% endblocktrans %},
-				{% blocktrans count counter=record.loss|default:0 %}{{ counter }} loss{% plural %}{{ counter }} losses{% endblocktrans %},
-				{% blocktrans count counter=record.draw|default:0 %}{{ counter }} draw{% plural %}{{ counter }} draws{% endblocktrans %}.
+				{% blocktrans with played=record.played %}Played {{ played }}: {{ wins }}, {{ losses }}, {{ draws }}.{% endblocktrans %}
 			</p>
 		{% endif %}
 	{% endblock %}

--- a/tournamentcontrol/competition/templates/tournamentcontrol/competition/team_timeline.html
+++ b/tournamentcontrol/competition/templates/tournamentcontrol/competition/team_timeline.html
@@ -18,7 +18,10 @@
 	{% block record %}
 		{% if record.played %}
 			<p class="team-record">
-				{% blocktrans with win=record.win|default:0 loss=record.loss|default:0 draw=record.draw|default:0 played=record.played %}Played {{ played }}: {{ win }} wins, {{ loss }} losses, {{ draw }} draws.{% endblocktrans %}
+				{% blocktrans with played=record.played %}Played {{ played }}:{% endblocktrans %}
+				{% blocktrans count counter=record.win|default:0 %}{{ counter }} win{% plural %}{{ counter }} wins{% endblocktrans %},
+				{% blocktrans count counter=record.loss|default:0 %}{{ counter }} loss{% plural %}{{ counter }} losses{% endblocktrans %},
+				{% blocktrans count counter=record.draw|default:0 %}{{ counter }} draw{% plural %}{{ counter }} draws{% endblocktrans %}.
 			</p>
 		{% endif %}
 	{% endblock %}

--- a/tournamentcontrol/competition/tests/test_experimental_views.py
+++ b/tournamentcontrol/competition/tests/test_experimental_views.py
@@ -290,6 +290,9 @@ class TeamTimelineTests(TestCase):
         record = self.last_response.context["record"]
         self.assertEqual(record["played"], 1)
         self.assertEqual(record["win"], 1)
+        self.assertResponseContains(
+            "Played 1: 1 win, 0 losses, 0 draws.", html=False
+        )
 
     def test_team_timeline_undecided_matches(self):
         finals = factories.StageFactory.create(


### PR DESCRIPTION
The season fixtures navigator `select_related` thirteen tables in a single query — including `home_team_eval_related` and `away_team_eval_related`, which are self-joins back onto the match table. On production-sized datasets the planner chose a catastrophic plan and the request died at the gunicorn worker timeout while still fetching rows (Sentry FIT-TOURNAMENTS-4T: `SystemExit` inside `cursor.fetchmany`).

Keep the base query narrow (matches + stage/division + venue for filtering and ordering) and load teams, clubs, undecided teams, and eval-related matches with flat prefetch_related queries instead. Apply the same shape to the team timeline's progression-match queryset.

Also pluralise the default team timeline record sentence correctly ("1 win", not "1 wins").

Fixes FIT-TOURNAMENTS-4T
