### PR TITLE
Stop fetching live-stream thumbnail blobs in match listings

### DIFF
--- a/tournamentcontrol/competition/models.py
+++ b/tournamentcontrol/competition/models.py
@@ -1341,6 +1341,9 @@ class Stage(AdminUrlMixin, OrderedSitemapNode):
                 "away_team__club",
                 "away_team__division",
             )
+            # live-stream thumbnail blobs are only needed by the thumbnail
+            # endpoints and YouTube sync — never in a match listing
+            .defer("live_stream_thumbnail_image")
             .annotate(
                 statistics_count=Count("statistics"),
                 videos_count=Count("videos"),

--- a/tournamentcontrol/competition/models.py
+++ b/tournamentcontrol/competition/models.py
@@ -916,6 +916,9 @@ class Division(
                 "away_team__club",
                 "away_team__division",
             )
+            # live-stream thumbnail blobs are only needed by the thumbnail
+            # endpoints and YouTube sync — never in a match listing
+            .defer("live_stream_thumbnail_image")
             .annotate(
                 statistics_count=Count("statistics"),
                 videos_count=Count("videos"),
@@ -1408,22 +1411,28 @@ class StageGroup(AdminUrlMixin, OrderedSitemapNode):
     def matches_by_date(self):
         tzinfo = timezone.get_current_timezone()
         res = collections.OrderedDict()
-        matches = self.matches.select_related(
-            "play_at",
-            "stage__division",
-            "stage_group",
-            "home_team__club",
-            "home_team__division",
-            "away_team__club",
-            "away_team__division",
-        ).order_by(
-            "date",
-            "stage",
-            "round",
-            "is_bye",
-            "time",
-            "play_at__ground__order",
-            "pk",
+        matches = (
+            self.matches.select_related(
+                "play_at",
+                "stage__division",
+                "stage_group",
+                "home_team__club",
+                "home_team__division",
+                "away_team__club",
+                "away_team__division",
+            )
+            # live-stream thumbnail blobs are only needed by the thumbnail
+            # endpoints and YouTube sync — never in a match listing
+            .defer("live_stream_thumbnail_image")
+            .order_by(
+                "date",
+                "stage",
+                "round",
+                "is_bye",
+                "time",
+                "play_at__ground__order",
+                "pk",
+            )
         )
         for match in matches.annotate(
             statistics_count=Count("statistics"),
@@ -1637,22 +1646,28 @@ class Team(AdminUrlMixin, OrderedSitemapNode):
     def matches_by_date(self):
         tzinfo = timezone.get_current_timezone()
         res = collections.OrderedDict()
-        matches = self.matches.select_related(
-            "play_at",
-            "stage__division",
-            "stage_group",
-            "home_team__club",
-            "home_team__division",
-            "away_team__club",
-            "away_team__division",
-        ).order_by(
-            "date",
-            "stage",
-            "round",
-            "is_bye",
-            "time",
-            "play_at__ground__order",
-            "pk",
+        matches = (
+            self.matches.select_related(
+                "play_at",
+                "stage__division",
+                "stage_group",
+                "home_team__club",
+                "home_team__division",
+                "away_team__club",
+                "away_team__division",
+            )
+            # live-stream thumbnail blobs are only needed by the thumbnail
+            # endpoints and YouTube sync — never in a match listing
+            .defer("live_stream_thumbnail_image")
+            .order_by(
+                "date",
+                "stage",
+                "round",
+                "is_bye",
+                "time",
+                "play_at__ground__order",
+                "pk",
+            )
         )
         for m in matches.annotate(
             statistics_count=Count("statistics"), videos_count=Count("videos")

--- a/tournamentcontrol/competition/sites.py
+++ b/tournamentcontrol/competition/sites.py
@@ -975,7 +975,7 @@ class CompetitionSite(CompetitionAdminMixin, Application):
             .select_related("play_at", "stage__division", "stage_group")
             # never drag live-stream thumbnail blobs out of the database
             # for a list view — hundreds of matches each carrying an image
-            # is tens of megabytes per request
+            # is hundreds of megabytes per request at tournament scale
             .defer("live_stream_thumbnail_image")
             .prefetch_related(
                 Prefetch("home_team", queryset=team_qs),

--- a/tournamentcontrol/competition/sites.py
+++ b/tournamentcontrol/competition/sites.py
@@ -973,6 +973,10 @@ class CompetitionSite(CompetitionAdminMixin, Application):
             .filter(stage__division__draft=False)
             .select_related(None)
             .select_related("play_at", "stage__division", "stage_group")
+            # never drag live-stream thumbnail blobs out of the database
+            # for a list view — hundreds of matches each carrying an image
+            # is tens of megabytes per request
+            .defer("live_stream_thumbnail_image")
             .prefetch_related(
                 Prefetch("home_team", queryset=team_qs),
                 Prefetch("away_team", queryset=team_qs),
@@ -1091,6 +1095,7 @@ class CompetitionSite(CompetitionAdminMixin, Application):
             .exclude(is_bye=True)
             .select_related(None)
             .select_related("play_at", "stage__division", "stage_group")
+            .defer("live_stream_thumbnail_image")
             .prefetch_related(
                 Prefetch("home_team", queryset=team_qs),
                 Prefetch("away_team", queryset=team_qs),

--- a/tournamentcontrol/competition/tests/test_experimental_views.py
+++ b/tournamentcontrol/competition/tests/test_experimental_views.py
@@ -59,7 +59,7 @@ class SeasonFixturesTests(TestCase):
 
         # the live-stream thumbnail blob must never be dragged out of the
         # database for a listing — hundreds of matches each carrying an
-        # image is tens of megabytes per request
+        # image is hundreds of megabytes per request at tournament scale
         matches_by_date = self.last_response.context["matches_by_date"]
         match = next(iter(matches_by_date.values()))[0]
         self.assertIn("live_stream_thumbnail_image", match.get_deferred_fields())

--- a/tournamentcontrol/competition/tests/test_experimental_views.py
+++ b/tournamentcontrol/competition/tests/test_experimental_views.py
@@ -57,6 +57,13 @@ class SeasonFixturesTests(TestCase):
         )
         self.assertEqual(self.last_response.context["match_count"], 5)
 
+        # the live-stream thumbnail blob must never be dragged out of the
+        # database for a listing — hundreds of matches each carrying an
+        # image is tens of megabytes per request
+        matches_by_date = self.last_response.context["matches_by_date"]
+        match = next(iter(matches_by_date.values()))[0]
+        self.assertIn("live_stream_thumbnail_image", match.get_deferred_fields())
+
     def test_season_fixtures_division_filter(self):
         stage1 = factories.StageFactory.create(division__season=self.season)
         stage2 = factories.StageFactory.create(division__season=self.season)
@@ -271,6 +278,12 @@ class TeamTimelineTests(TestCase):
         # the time since the earlier start
         self.assertIsNone(items[0]["gap"])
         self.assertEqual(str(items[1]["gap_display"]), "3h")
+
+        # thumbnail blobs stay in the database for timeline listings too
+        self.assertIn(
+            "live_stream_thumbnail_image",
+            items[0]["match"].get_deferred_fields(),
+        )
 
         # the played match is not "next", the unplayed one is
         self.assertEqual(items[0]["is_next"], False)


### PR DESCRIPTION
## Summary

The real root cause of the fixtures-page timeouts, found by reproducing a full downstream production stack locally (CMS mounting, project theme templates, real data shape) and proving it with a controlled experiment.

`Match.live_stream_thumbnail_image` is a `BinaryField` holding a full JPEG — ~335KB per match on a live-streamed event. Every match-listing queryset selected the column and threw it away. A tournament-scale season can render close to a thousand matches on the unfiltered fixtures page, so each request pulled hundreds of megabytes out of the database — which at managed-DB throughput matches the observed ~59s, and why workers died inside `cursor.fetchmany` (`SystemExit` stack traces at the worker timeout) both before and after #295. #295's join fix was real but only ~20% of the cost.

## Change

`.defer("live_stream_thumbnail_image")` on:

- the experimental `season_fixtures` and `team_timeline` querysets;
- the shared `matches_by_date` helpers on `Team`, `Stage`, and `Division` — so the existing team/stage/division pages (which pay the same tax) benefit too.

The blob is only used by the thumbnail endpoints and the YouTube sync task, which load their own instances. Deferred access still lazy-loads if any code path ever touches it, so this cannot break functionality — worst case is one extra query.

## Verification

Controlled experiment on a local clone of the downstream production stack (676 synthetic matches, CMS-mounted `CompetitionSite`, project theme templates):

| Scenario | Unfiltered fixtures render |
|---|---|
| No blobs | 0.89s |
| 334KB blob on every match, before this change | 3.61s (localhost; production network → ~59s) |
| 334KB blob on every match, **with this change** | **0.93s** |

- Full `tournamentcontrol.competition` suite: **321 tests pass** (4 skips, 4 expected failures — same as main). New assertions verify the field is deferred in both experimental views.
- Same environment note as previous PRs: no Docker available, so the suite ran via the identical command tox uses against a local postgres 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Srv6Tu5an3Mk3dXbv5daSj