### PR TITLE
Redesign live-stream toggle as time/field-ordered rows

### DIFF
--- a/tests/e2e/test_match_live_stream.py
+++ b/tests/e2e/test_match_live_stream.py
@@ -1,0 +1,185 @@
+"""E2E tests for the bulk live-stream toggle admin page."""
+
+from datetime import date, time
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from tournamentcontrol.competition.tests.factories import (
+    DivisionFactory,
+    GroundFactory,
+    MatchFactory,
+    SeasonFactory,
+    StageFactory,
+    TeamFactory,
+    VenueFactory,
+)
+
+
+class TestMatchLiveStream:
+    """Tests for the runsheet's bulk live-stream toggle page."""
+
+    @pytest.fixture
+    def live_stream_dataset(self, db):
+        """
+        Build matches whose time+field order deliberately contradicts
+        their division order, so tests can prove rows are ordered by
+        time then field -- not grouped or ordered by division.
+        """
+        season = SeasonFactory.create(timezone="Australia/Sydney")
+        venue = VenueFactory.create(season=season)
+
+        # Created in this order so ground_1.pk < ground_2.pk.
+        ground_1 = GroundFactory.create(venue=venue, title="Court 1", live_stream=True)
+        ground_2 = GroundFactory.create(venue=venue, title="Court 2", live_stream=True)
+
+        division_alpha = DivisionFactory.create(season=season, title="Alpha Division")
+        division_beta = DivisionFactory.create(season=season, title="Beta Division")
+
+        stage_alpha = StageFactory.create(division=division_alpha, title="Stage 1")
+        stage_beta = StageFactory.create(division=division_beta, title="Stage 1")
+
+        team_alpha_1 = TeamFactory.create(division=division_alpha, title="Alpha One")
+        team_alpha_2 = TeamFactory.create(division=division_alpha, title="Alpha Two")
+        team_beta_1 = TeamFactory.create(division=division_beta, title="Beta One")
+        team_beta_2 = TeamFactory.create(division=division_beta, title="Beta Two")
+
+        match_day = date(2024, 6, 15)
+
+        # 09:00 on Court 1 -- Beta division, should render FIRST.
+        match_early_court1 = MatchFactory.create(
+            stage=stage_beta,
+            home_team=team_beta_1,
+            away_team=team_beta_2,
+            date=match_day,
+            time=time(9, 0),
+            play_at=ground_1,
+        )
+        # 09:00 on Court 2 -- Alpha division, should render SECOND
+        # (same time as above, but a later field breaks the tie).
+        match_early_court2 = MatchFactory.create(
+            stage=stage_alpha,
+            home_team=team_alpha_1,
+            away_team=team_alpha_2,
+            date=match_day,
+            time=time(9, 0),
+            play_at=ground_2,
+        )
+        # 11:00 on Court 1 -- Beta division again, should render LAST
+        # despite matching match_early_court1's division and field.
+        match_late_court1 = MatchFactory.create(
+            stage=stage_beta,
+            home_team=team_beta_2,
+            away_team=team_beta_1,
+            date=match_day,
+            time=time(11, 0),
+            play_at=ground_1,
+        )
+
+        return {
+            "season": season,
+            "match_day": match_day,
+            "match_early_court1": match_early_court1,
+            "match_early_court2": match_early_court2,
+            "match_late_court1": match_late_court1,
+        }
+
+    def _live_stream_url(self, live_server, season, match_day):
+        return (
+            f"{live_server.url}/admin/fixja/competition/{season.competition.pk}"
+            f"/seasons/{season.pk}/{match_day.strftime('%Y%m%d')}/live-stream/"
+        )
+
+    def test_rows_ordered_by_time_then_field(
+        self, authenticated_page: Page, live_server, live_stream_dataset
+    ):
+        """Rows must be ordered by time then field, not by division."""
+        page = authenticated_page
+        data = live_stream_dataset
+
+        page.goto(
+            self._live_stream_url(live_server, data["season"], data["match_day"])
+        )
+        expect(page.locator(".live-stream-row")).to_have_count(3)
+
+        row_texts = page.locator(".live-stream-row").all_inner_texts()
+
+        # Expected order: 09:00/Court 1, 09:00/Court 2, 11:00/Court 1.
+        assert "Alpha One vs Beta" not in row_texts[0]
+        assert "9 a.m." in row_texts[0] and "Court 1" in row_texts[0]
+        assert "Beta One" in row_texts[0] or "Beta Two" in row_texts[0]
+
+        assert "9 a.m." in row_texts[1] and "Court 2" in row_texts[1]
+        assert "Alpha One" in row_texts[1] or "Alpha Two" in row_texts[1]
+
+        assert "11 a.m." in row_texts[2] and "Court 1" in row_texts[2]
+        assert "Beta One" in row_texts[2] or "Beta Two" in row_texts[2]
+
+    def test_row_shows_time_division_field_match_and_toggle(
+        self, authenticated_page: Page, live_server, live_stream_dataset
+    ):
+        """Each row must show time, division, field, the match, and the toggle."""
+        page = authenticated_page
+        data = live_stream_dataset
+
+        page.goto(
+            self._live_stream_url(live_server, data["season"], data["match_day"])
+        )
+
+        first_row = page.locator(".live-stream-row").first
+        expect(first_row).to_contain_text("9 a.m.")
+        expect(first_row).to_contain_text("Beta Division")
+        expect(first_row).to_contain_text("Court 1")
+        expect(first_row).to_contain_text("Beta One")
+        expect(first_row.locator("select")).to_be_visible()
+
+    def test_desktop_and_mobile_layout(
+        self, authenticated_page: Page, live_server, live_stream_dataset, screenshot_dir
+    ):
+        """
+        Desktop: time/division/field/match sit on one line (table-like).
+        Mobile: they stack onto separate lines, with the toggle staying
+        to the right of the stacked block, and each match visually grouped.
+        """
+        page = authenticated_page
+        data = live_stream_dataset
+
+        page.goto(
+            self._live_stream_url(live_server, data["season"], data["match_day"])
+        )
+        expect(page.locator(".live-stream-row")).to_have_count(3)
+
+        # Desktop (conftest's default 1920x1080 viewport).
+        page.screenshot(
+            path=str(screenshot_dir / "live_stream_desktop.png"), full_page=True
+        )
+
+        first_row = page.locator(".live-stream-row").first
+        time_box = first_row.locator(".row .row > div").nth(0).bounding_box()
+        division_box = first_row.locator(".row .row > div").nth(1).bounding_box()
+        select_box = first_row.locator("select").bounding_box()
+
+        # On desktop, time and division sit on the same line.
+        assert abs(time_box["y"] - division_box["y"]) < 5
+        # The toggle sits to the right of the info block.
+        assert select_box["x"] > division_box["x"]
+
+        # Mobile viewport.
+        page.set_viewport_size({"width": 375, "height": 812})
+        page.screenshot(
+            path=str(screenshot_dir / "live_stream_mobile.png"), full_page=True
+        )
+
+        first_row = page.locator(".live-stream-row").first
+        time_box = first_row.locator(".row .row > div").nth(0).bounding_box()
+        division_box = first_row.locator(".row .row > div").nth(1).bounding_box()
+        field_box = first_row.locator(".row .row > div").nth(2).bounding_box()
+        select_box = first_row.locator("select").bounding_box()
+
+        # On mobile, time/division/field stack onto separate lines.
+        assert division_box["y"] > time_box["y"]
+        assert field_box["y"] > division_box["y"]
+        # The toggle still sits to the right of the stacked block, roughly
+        # vertically centered alongside it rather than pushed below it.
+        assert select_box["x"] > time_box["x"]
+        assert select_box["y"] < field_box["y"]

--- a/tests/e2e/test_match_live_stream.py
+++ b/tests/e2e/test_match_live_stream.py
@@ -49,9 +49,11 @@ class TestMatchLiveStream:
         match_day = date(2024, 6, 15)
         # MatchFactory's `datetime` attribute defaults to a random FuzzyDateTime
         # unless given explicitly -- date=/time= alone do not derive it, so it
-        # must be set directly here for deterministic ordering.
-        early = datetime(2024, 6, 15, 0, 0, tzinfo=ZoneInfo("UTC"))
-        late = datetime(2024, 6, 15, 2, 0, tzinfo=ZoneInfo("UTC"))
+        # must be set directly here for deterministic ordering. Chosen to land
+        # on 09:00/11:00 Australia/Sydney (UTC+10 in June), avoiding exact
+        # midnight/noon, which Django's time filter renders as literal words.
+        early = datetime(2024, 6, 14, 23, 0, tzinfo=ZoneInfo("UTC"))
+        late = datetime(2024, 6, 15, 1, 0, tzinfo=ZoneInfo("UTC"))
 
         # Same instant as match_early_court2 on a lower-pk field -- should
         # render FIRST (field breaks the time tie).

--- a/tests/e2e/test_match_live_stream.py
+++ b/tests/e2e/test_match_live_stream.py
@@ -1,6 +1,8 @@
 """E2E tests for the bulk live-stream toggle admin page."""
 
-from datetime import date, time
+import re
+from datetime import date, datetime, time
+from zoneinfo import ZoneInfo
 
 import pytest
 from playwright.sync_api import Page, expect
@@ -45,34 +47,43 @@ class TestMatchLiveStream:
         team_beta_2 = TeamFactory.create(division=division_beta, title="Beta Two")
 
         match_day = date(2024, 6, 15)
+        # MatchFactory's `datetime` attribute defaults to a random FuzzyDateTime
+        # unless given explicitly -- date=/time= alone do not derive it, so it
+        # must be set directly here for deterministic ordering.
+        early = datetime(2024, 6, 15, 0, 0, tzinfo=ZoneInfo("UTC"))
+        late = datetime(2024, 6, 15, 2, 0, tzinfo=ZoneInfo("UTC"))
 
-        # 09:00 on Court 1 -- Beta division, should render FIRST.
+        # Same instant as match_early_court2 on a lower-pk field -- should
+        # render FIRST (field breaks the time tie).
         match_early_court1 = MatchFactory.create(
             stage=stage_beta,
             home_team=team_beta_1,
             away_team=team_beta_2,
             date=match_day,
             time=time(9, 0),
+            datetime=early,
             play_at=ground_1,
         )
-        # 09:00 on Court 2 -- Alpha division, should render SECOND
-        # (same time as above, but a later field breaks the tie).
+        # Same instant as match_early_court1 on a higher-pk field -- should
+        # render SECOND, despite being a different division to court 1's match.
         match_early_court2 = MatchFactory.create(
             stage=stage_alpha,
             home_team=team_alpha_1,
             away_team=team_alpha_2,
             date=match_day,
             time=time(9, 0),
+            datetime=early,
             play_at=ground_2,
         )
-        # 11:00 on Court 1 -- Beta division again, should render LAST
-        # despite matching match_early_court1's division and field.
+        # Later instant, same division and field as match_early_court1 --
+        # should render LAST despite matching that match's division and field.
         match_late_court1 = MatchFactory.create(
             stage=stage_beta,
             home_team=team_beta_2,
             away_team=team_beta_1,
             date=match_day,
             time=time(11, 0),
+            datetime=late,
             play_at=ground_1,
         )
 
@@ -104,16 +115,17 @@ class TestMatchLiveStream:
 
         row_texts = page.locator(".live-stream-row").all_inner_texts()
 
-        # Expected order: 09:00/Court 1, 09:00/Court 2, 11:00/Court 1.
-        assert "Alpha One vs Beta" not in row_texts[0]
-        assert "9 a.m." in row_texts[0] and "Court 1" in row_texts[0]
-        assert "Beta One" in row_texts[0] or "Beta Two" in row_texts[0]
+        # match_early_court1 and match_late_court1 share a division and field,
+        # but reversed home/away, so their text distinguishes them without
+        # needing to parse the (timezone-dependent) rendered clock time.
+        assert "Court 1" in row_texts[0]
+        assert "Beta One vs Beta Two" in row_texts[0]
 
-        assert "9 a.m." in row_texts[1] and "Court 2" in row_texts[1]
-        assert "Alpha One" in row_texts[1] or "Alpha Two" in row_texts[1]
+        assert "Court 2" in row_texts[1]
+        assert "Alpha One" in row_texts[1] and "Alpha Two" in row_texts[1]
 
-        assert "11 a.m." in row_texts[2] and "Court 1" in row_texts[2]
-        assert "Beta One" in row_texts[2] or "Beta Two" in row_texts[2]
+        assert "Court 1" in row_texts[2]
+        assert "Beta Two vs Beta One" in row_texts[2]
 
     def test_row_shows_time_division_field_match_and_toggle(
         self, authenticated_page: Page, live_server, live_stream_dataset
@@ -127,7 +139,9 @@ class TestMatchLiveStream:
         )
 
         first_row = page.locator(".live-stream-row").first
-        expect(first_row).to_contain_text("9 a.m.")
+        # Time is rendered in the season's local timezone, so match on
+        # shape (e.g. "9 a.m." / "9:00 a.m.") rather than a literal string.
+        expect(first_row).to_contain_text(re.compile(r"\d{1,2}(:\d{2})?\s*[ap]\.m\."))
         expect(first_row).to_contain_text("Beta Division")
         expect(first_row).to_contain_text("Court 1")
         expect(first_row).to_contain_text("Beta One")

--- a/tournamentcontrol/competition/admin.py
+++ b/tournamentcontrol/competition/admin.py
@@ -2220,7 +2220,7 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
             stage__division__season__competition__id=competition.pk,
             date=date,
             play_at__ground__live_stream=True,
-        ).order_by("stage__division__order", "is_bye", "datetime", "play_at")
+        ).order_by("datetime", "play_at", "pk")
 
         return self.generic_edit_multiple(
             request,

--- a/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/match_live_stream.html
+++ b/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/match_live_stream.html
@@ -1,5 +1,5 @@
 {% extends "touchtechnology/admin/edit.html" %}
-{% load i18n common %}
+{% load i18n common tz %}
 
 {% block content %}
 	<form class="form-horizontal" action="" method="post">
@@ -25,28 +25,30 @@
 			<div class="col-sm-2"></div>
 		</div>
 
-		<div class="list-group live-stream-list">
-			{% for form in formset.forms %}
-				{% with match=form.instance %}
-					<div class="list-group-item live-stream-row">
-						{{ form.id }}
-						<div class="row">
-							<div class="col-xs-9 col-sm-10">
-								<div class="row">
-									<div class="col-sm-2">{{ match.datetime|time }}</div>
-									<div class="col-sm-3">{{ match.stage.division.short_title|default:match.stage.division.title|htmlentities }}</div>
-									<div class="col-sm-2">{{ match.play_at.title|htmlentities }}</div>
-									<div class="col-sm-5">{{ match|safe }}</div>
+		{% timezone season.timezone %}
+			<div class="list-group live-stream-list">
+				{% for form in formset.forms %}
+					{% with match=form.instance %}
+						<div class="list-group-item live-stream-row">
+							{{ form.id }}
+							<div class="row">
+								<div class="col-xs-9 col-sm-10">
+									<div class="row">
+										<div class="col-sm-2">{{ match.datetime|time }}</div>
+										<div class="col-sm-3">{{ match.stage.division.short_title|default:match.stage.division.title|htmlentities }}</div>
+										<div class="col-sm-2">{{ match.play_at.title|htmlentities }}</div>
+										<div class="col-sm-5">{{ match|safe }}</div>
+									</div>
+								</div>
+								<div class="col-xs-3 col-sm-2 text-right">
+									{{ form.live_stream }}
 								</div>
 							</div>
-							<div class="col-xs-3 col-sm-2 text-right">
-								{{ form.live_stream }}
-							</div>
 						</div>
-					</div>
-				{% endwith %}
-			{% endfor %}
-		</div>
+					{% endwith %}
+				{% endfor %}
+			</div>
+		{% endtimezone %}
 
 		<div class="form-group">
 			<div class="text-center">

--- a/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/match_live_stream.html
+++ b/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/match_live_stream.html
@@ -1,5 +1,5 @@
 {% extends "touchtechnology/admin/edit.html" %}
-{% load i18n %}
+{% load i18n common %}
 
 {% block content %}
 	<form class="form-horizontal" action="" method="post">
@@ -11,34 +11,42 @@
 
 		{{ formset.management_form }}
 
-		{% regroup formset.forms by instance.stage.division as grouped %}
+		<p>{% blocktrans %}Mark which matches on camera-equipped fields should be live streamed to YouTube.{% endblocktrans %}</p>
 
-		<div class="tab-pane active" id="live-stream-tab">
-			<p>{% blocktrans %}Mark which matches on camera-equipped fields should be live streamed to YouTube.{% endblocktrans %}</p>
+		<div class="row hidden-xs live-stream-header">
+			<div class="col-sm-10">
+				<div class="row">
+					<div class="col-sm-2"><strong>{% trans "Time" %}</strong></div>
+					<div class="col-sm-3"><strong>{% trans "Division" %}</strong></div>
+					<div class="col-sm-2"><strong>{% trans "Field" %}</strong></div>
+					<div class="col-sm-5"><strong>{% trans "Match" %}</strong></div>
+				</div>
+			</div>
+			<div class="col-sm-2"></div>
+		</div>
 
-			{% for group in grouped %}
-				<fieldset>
-					<legend>{{ group.grouper }}</legend>
-
-					{% for form in group.list %}
-						{% with match=form.instance %}
-							{% with home=match.get_home_team away=match.get_away_team %}
-								<div class="col-sm-6">
-									{{ form.id }}
-									<div class="form-group">
-										<label class="control-label col-md-7">{{ match|safe }}</label>
-										<div class="col-md-5">
-											{{ form.live_stream }}
-										</div>
-									</div>
+		<div class="list-group live-stream-list">
+			{% for form in formset.forms %}
+				{% with match=form.instance %}
+					<div class="list-group-item live-stream-row">
+						{{ form.id }}
+						<div class="row">
+							<div class="col-xs-9 col-sm-10">
+								<div class="row">
+									<div class="col-sm-2">{{ match.datetime|time }}</div>
+									<div class="col-sm-3">{{ match.stage.division.short_title|default:match.stage.division.title|htmlentities }}</div>
+									<div class="col-sm-2">{{ match.play_at.title|htmlentities }}</div>
+									<div class="col-sm-5">{{ match|safe }}</div>
 								</div>
-							{% endwith %}
-						{% endwith %}
-					{% endfor %}
-				</fieldset>
+							</div>
+							<div class="col-xs-3 col-sm-2 text-right">
+								{{ form.live_stream }}
+							</div>
+						</div>
+					</div>
+				{% endwith %}
 			{% endfor %}
 		</div>
-		<div class="clearfix"></div>
 
 		<div class="form-group">
 			<div class="text-center">


### PR DESCRIPTION
## Summary
- Replaces the division-grouped, teams-only layout on the bulk live-stream toggle page (cloned from Washout) with rows showing time, division, field, and the match.
- Orders rows by time then field instead of grouping by division -- streaming decisions depend on time-slot and field, not division.
- Responsive via Bootstrap 3 grid only (no new CSS): table-like on desktop, stacked lines with the toggle staying to the right on mobile, one visual grouping per match.

## Test plan
- [ ] New `tests/e2e/test_match_live_stream.py`: asserts DOM row order is time-then-field (independent of division), each row shows all required info, and desktop/mobile layout via screenshot + bounding-box checks.
- [ ] CI screenshots (`tests/screenshots/live_stream_desktop.png`, `tests/screenshots/live_stream_mobile.png`) to be reviewed visually before merge.
- [ ] Full Django test matrix for regressions.

https://claude.ai/code/session_019Dw3AzDNFQp9vggdwAw8DA