### PR TITLE
Fix missing YouTube sync on bulk live-stream toggle, add bulk resync

### DIFF
--- a/tournamentcontrol/competition/admin.py
+++ b/tournamentcontrol/competition/admin.py
@@ -575,6 +575,11 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
             ),
             path("washout/", self.match_washout, name="match-washout"),
             path("live-stream/", self.match_live_stream, name="match-live-stream"),
+            path(
+                "live-stream/resync/",
+                self.match_live_stream_resync,
+                name="match-live-stream-resync",
+            ),
             path("schedule/", self.match_schedule, name="match-schedule"),
             path(
                 "schedule/<int:division_id>/",
@@ -2222,14 +2227,82 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
             play_at__ground__live_stream=True,
         ).order_by("datetime", "play_at", "pk")
 
+        base_url = request.build_absolute_uri("/").rstrip("/")
+
+        def post_save_callback(obj: Match):
+            # Check if YouTube credentials are configured before queuing anything,
+            # we can't interact with the YouTube API without them.
+            if not (season.live_stream_client_id and season.live_stream_client_secret):
+                return None
+            # An existing broadcast always needs syncing (update or delete). For
+            # insert/update we additionally need a scheduled datetime, otherwise
+            # the task would just no-op after rendering templates.
+            if not obj.external_identifier:
+                if not obj.live_stream:
+                    return None
+                if obj.get_datetime(ZoneInfo("UTC")) is None:
+                    return None
+            sync_live_stream.s(obj.pk, base_url=base_url).apply_async()
+            return None
+
         return self.generic_edit_multiple(
             request,
             matches,
             formset_class=MatchLiveStreamFormSet,
             templates=self.template_path("match_live_stream.html"),
+            post_save_callback=post_save_callback,
             post_save_redirect=self.redirect(season.urls["edit"]),
             extra_context=extra_context,
         )
+
+    @competition_by_pk_m
+    @staff_login_required_m
+    def match_live_stream_resync(
+        self, request, competition, season, date, extra_context, **kwargs
+    ):
+        """Re-push every already-streaming match on camera-equipped fields for the day.
+
+        A quick bulk equivalent of the per-match "Resync live stream" action --
+        useful after changing the season's thumbnail, or to pick up any match
+        whose broadcast fell out of sync with its current title/schedule.
+        """
+        redirect_url = season.urls["edit"]
+
+        if request.method != "POST":
+            return self.redirect(redirect_url)
+
+        if not (season.live_stream_client_id and season.live_stream_client_secret):
+            messages.error(
+                request, _("Live streaming is not configured for this season.")
+            )
+            return self.redirect(redirect_url)
+
+        matches = Match.objects.filter(
+            stage__division__season__id=season.pk,
+            stage__division__season__competition__id=competition.pk,
+            date=date,
+            play_at__ground__live_stream=True,
+            live_stream=True,
+        ).exclude(external_identifier__isnull=True).exclude(external_identifier="")
+
+        base_url = request.build_absolute_uri("/").rstrip("/")
+        count = 0
+        for match in matches:
+            sync_live_stream.s(match.pk, base_url=base_url).apply_async()
+            count += 1
+
+        if count:
+            message = ngettext(
+                "YouTube live stream resync has been queued for %(count)d match.",
+                "YouTube live stream resync has been queued for %(count)d matches.",
+                count,
+            ) % {"count": count}
+            messages.success(request, message)
+        else:
+            messages.info(
+                request, _("No currently-streaming matches to resync for this day.")
+            )
+        return self.redirect(redirect_url)
 
     @staff_login_required_m
     def scorecard_report(self, request, **extra_context):

--- a/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/match_live_stream.html
+++ b/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/match_live_stream.html
@@ -57,4 +57,17 @@
 			</div> <!-- /.col -->
 		</div>
 	</form>
+
+	<form class="form-horizontal" action="{% url 'admin:fixja:match-live-stream-resync' season.competition.pk season.pk date|date:"Ymd" %}" method="post">
+		{% csrf_token %}
+		<div class="form-group">
+			<div class="text-center">
+				<button type="submit" class="btn btn-default">
+					<i class="fa fa-refresh fa-fw"></i>
+					{% trans "Resync All" %}
+				</button>
+				<p class="help-block">{% blocktrans %}Re-push title, thumbnail, and schedule to YouTube for every match above that is already streaming.{% endblocktrans %}</p>
+			</div>
+		</div>
+	</form>
 {% endblock %}

--- a/tournamentcontrol/competition/tests/test_competition_admin.py
+++ b/tournamentcontrol/competition/tests/test_competition_admin.py
@@ -1,6 +1,6 @@
 import unittest
 from datetime import date, datetime, time
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import ANY, MagicMock, PropertyMock, patch
 from zoneinfo import ZoneInfo
 
 from dateutil.rrule import DAILY
@@ -479,6 +479,29 @@ class GoodViewTests(TestCase):
 
         self.assertLoginRequired(
             "admin:fixja:match-live-stream",
+            season.competition.pk,
+            season.pk,
+            "20250501",
+        )
+
+    def test_match_live_stream_resync_requires_staff_login(self):
+        stage = factories.StageFactory.create()
+        camera_ground = factories.GroundFactory.create(
+            venue__season=stage.division.season, live_stream=True
+        )
+        factories.MatchFactory.create(
+            stage=stage,
+            play_at=camera_ground,
+            live_stream=True,
+            external_identifier="yt-broadcast-1",
+            date=date(2025, 5, 1),
+            time=time(14, 0),
+            datetime=datetime(2025, 5, 1, 4, 0, tzinfo=ZoneInfo("UTC")),
+        )
+        season = stage.division.season
+
+        self.assertLoginRequired(
+            "admin:fixja:match-live-stream-resync",
             season.competition.pk,
             season.pk,
             "20250501",
@@ -2498,6 +2521,209 @@ class BackendTests(MessagesTestMixin, TestCase):
         self.response_200()
         self.assertContains(self.last_response, streaming_resync_url)
         self.assertNotContains(self.last_response, not_yet_streaming_resync_url)
+
+    @patch("tournamentcontrol.competition.admin.sync_live_stream")
+    def test_match_live_stream_post_enqueues_sync_when_configured(
+        self, mock_sync_live_stream
+    ):
+        stage = factories.StageFactory.create(
+            division__season__live_stream=True,
+            division__season__live_stream_client_id="test-client-id",
+            division__season__live_stream_client_secret="test-client-secret",
+        )
+        camera_ground = factories.GroundFactory.create(
+            venue__season=stage.division.season, live_stream=True
+        )
+        match_to_turn_on = factories.MatchFactory.create(
+            stage=stage,
+            play_at=camera_ground,
+            live_stream=False,
+            external_identifier=None,
+            date=date(2025, 5, 1),
+            time=time(14, 0),
+            datetime=datetime(2025, 5, 1, 4, 0, tzinfo=ZoneInfo("UTC")),
+        )
+        season = stage.division.season
+
+        data = {
+            "form-TOTAL_FORMS": "1",
+            "form-INITIAL_FORMS": "1",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+            "form-0-id": str(match_to_turn_on.pk),
+            "form-0-live_stream": "1",
+        }
+
+        with self.login(self.superuser):
+            self.post(
+                "admin:fixja:match-live-stream",
+                season.competition.pk,
+                season.pk,
+                "20250501",
+                data=data,
+            )
+        self.response_302()
+
+        mock_sync_live_stream.s.assert_called_once_with(
+            match_to_turn_on.pk, base_url=ANY
+        )
+        mock_sync_live_stream.s.return_value.apply_async.assert_called_once()
+
+    @patch("tournamentcontrol.competition.admin.sync_live_stream")
+    def test_match_live_stream_post_skips_sync_when_season_not_configured(
+        self, mock_sync_live_stream
+    ):
+        stage = factories.StageFactory.create()
+        camera_ground = factories.GroundFactory.create(
+            venue__season=stage.division.season, live_stream=True
+        )
+        match_to_turn_on = factories.MatchFactory.create(
+            stage=stage,
+            play_at=camera_ground,
+            live_stream=False,
+            date=date(2025, 5, 1),
+            time=time(14, 0),
+            datetime=datetime(2025, 5, 1, 4, 0, tzinfo=ZoneInfo("UTC")),
+        )
+        season = stage.division.season
+
+        data = {
+            "form-TOTAL_FORMS": "1",
+            "form-INITIAL_FORMS": "1",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+            "form-0-id": str(match_to_turn_on.pk),
+            "form-0-live_stream": "1",
+        }
+
+        with self.login(self.superuser):
+            self.post(
+                "admin:fixja:match-live-stream",
+                season.competition.pk,
+                season.pk,
+                "20250501",
+                data=data,
+            )
+        self.response_302()
+
+        mock_sync_live_stream.s.assert_not_called()
+
+    @patch("tournamentcontrol.competition.admin.sync_live_stream")
+    def test_match_live_stream_resync_queues_all_streaming_matches(
+        self, mock_sync_live_stream
+    ):
+        stage = factories.StageFactory.create(
+            division__season__live_stream=True,
+            division__season__live_stream_client_id="test-client-id",
+            division__season__live_stream_client_secret="test-client-secret",
+        )
+        camera_ground = factories.GroundFactory.create(
+            venue__season=stage.division.season, live_stream=True
+        )
+        streaming_match_1 = factories.MatchFactory.create(
+            stage=stage,
+            play_at=camera_ground,
+            live_stream=True,
+            external_identifier="yt-broadcast-1",
+            date=date(2025, 5, 1),
+            time=time(14, 0),
+            datetime=datetime(2025, 5, 1, 4, 0, tzinfo=ZoneInfo("UTC")),
+        )
+        streaming_match_2 = factories.MatchFactory.create(
+            stage=stage,
+            play_at=camera_ground,
+            live_stream=True,
+            external_identifier="yt-broadcast-2",
+            date=date(2025, 5, 1),
+            time=time(15, 0),
+            datetime=datetime(2025, 5, 1, 5, 0, tzinfo=ZoneInfo("UTC")),
+        )
+        # Not streaming -- must be skipped.
+        factories.MatchFactory.create(
+            stage=stage,
+            play_at=camera_ground,
+            live_stream=False,
+            external_identifier=None,
+            date=date(2025, 5, 1),
+            time=time(16, 0),
+            datetime=datetime(2025, 5, 1, 6, 0, tzinfo=ZoneInfo("UTC")),
+        )
+        # Marked live_stream but never actually broadcast -- must be skipped.
+        factories.MatchFactory.create(
+            stage=stage,
+            play_at=camera_ground,
+            live_stream=True,
+            external_identifier=None,
+            date=date(2025, 5, 1),
+            time=time(17, 0),
+            datetime=datetime(2025, 5, 1, 7, 0, tzinfo=ZoneInfo("UTC")),
+        )
+        season = stage.division.season
+
+        with self.login(self.superuser):
+            self.post(
+                "admin:fixja:match-live-stream-resync",
+                season.competition.pk,
+                season.pk,
+                "20250501",
+            )
+        self.response_302()
+
+        queued_pks = {call.args[0] for call in mock_sync_live_stream.s.call_args_list}
+        self.assertEqual(queued_pks, {streaming_match_1.pk, streaming_match_2.pk})
+        self.assertEqual(
+            mock_sync_live_stream.s.return_value.apply_async.call_count, 2
+        )
+
+    @patch("tournamentcontrol.competition.admin.sync_live_stream")
+    def test_match_live_stream_resync_refuses_when_not_configured(
+        self, mock_sync_live_stream
+    ):
+        stage = factories.StageFactory.create()
+        season = stage.division.season
+
+        with self.login(self.superuser):
+            self.post(
+                "admin:fixja:match-live-stream-resync",
+                season.competition.pk,
+                season.pk,
+                "20250501",
+            )
+        self.response_302()
+
+        mock_sync_live_stream.s.assert_not_called()
+
+    @patch("tournamentcontrol.competition.admin.sync_live_stream")
+    def test_match_live_stream_resync_ignores_get(self, mock_sync_live_stream):
+        stage = factories.StageFactory.create(
+            division__season__live_stream=True,
+            division__season__live_stream_client_id="test-client-id",
+            division__season__live_stream_client_secret="test-client-secret",
+        )
+        camera_ground = factories.GroundFactory.create(
+            venue__season=stage.division.season, live_stream=True
+        )
+        factories.MatchFactory.create(
+            stage=stage,
+            play_at=camera_ground,
+            live_stream=True,
+            external_identifier="yt-broadcast-1",
+            date=date(2025, 5, 1),
+            time=time(14, 0),
+            datetime=datetime(2025, 5, 1, 4, 0, tzinfo=ZoneInfo("UTC")),
+        )
+        season = stage.division.season
+
+        with self.login(self.superuser):
+            self.get(
+                "admin:fixja:match-live-stream-resync",
+                season.competition.pk,
+                season.pk,
+                "20250501",
+            )
+        self.response_302()
+
+        mock_sync_live_stream.s.assert_not_called()
 
 
 class TeamEditViewQueryTests(TestCase):


### PR DESCRIPTION
## Summary
- **Bug fix**: the bulk live-stream toggle page (`match_live_stream`) saved via a plain `ModelFormSet` with no `post_save_callback`, so toggling `Match.live_stream` never enqueued `sync_live_stream` -- the YouTube broadcast was silently never created/updated/deleted. Confirmed via Sentry: zero log/error entries mentioning `live_stream`/`sync_live_stream` in the last two weeks, consistent with the task simply never firing. Fixed by wiring the same `post_save_callback` the single-match `edit_match` view already uses.
- **New feature**: a "Resync All" bulk action on the same page, since `formset.save()` only returns changed forms -- re-saving with nothing toggled can't resync already-streaming matches (e.g. after updating the season thumbnail, or to backfill matches missed by the bug above). Reuses `_apply_sync`'s existing create-or-update upsert semantics (keyed on `external_identifier`) -- no new YouTube API logic, just triggers the existing task for every already-streaming match on camera-equipped fields that day.

## Test plan
- [ ] New unit tests mocking `sync_live_stream` to verify: toggling enqueues sync when the season is configured, is skipped when it isn't, "Resync All" queues every currently-streaming match and skips non-streaming/never-broadcast ones, refuses when unconfigured, and ignores GET.
- [ ] Full Django test matrix for regressions.

https://claude.ai/code/session_019Dw3AzDNFQp9vggdwAw8DA