### PR TITLE
Fix bulk resync to create broadcasts, not just update existing ones

### DIFF
--- a/tournamentcontrol/competition/admin.py
+++ b/tournamentcontrol/competition/admin.py
@@ -2260,11 +2260,15 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
     def match_live_stream_resync(
         self, request, competition, season, date, extra_context, **kwargs
     ):
-        """Re-push every already-streaming match on camera-equipped fields for the day.
+        """Re-push every match marked to stream on camera-equipped fields for the day.
 
-        A quick bulk equivalent of the per-match "Resync live stream" action --
-        useful after changing the season's thumbnail, or to pick up any match
-        whose broadcast fell out of sync with its current title/schedule.
+        A quick bulk equivalent of the per-match "Resync live stream" action, but
+        create-or-update rather than update-only: it also creates the broadcast for
+        matches that were marked to stream but never got one synced (e.g. toggled
+        via the bulk view before sync_live_stream was wired up to it), in addition
+        to updating already-created broadcasts (e.g. after changing the season
+        thumbnail). Relies on sync_live_stream/_apply_sync's existing
+        create-or-update semantics, keyed on external_identifier.
         """
         redirect_url = season.urls["edit"]
 
@@ -2283,11 +2287,15 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
             date=date,
             play_at__ground__live_stream=True,
             live_stream=True,
-        ).exclude(external_identifier__isnull=True).exclude(external_identifier="")
+        )
 
         base_url = request.build_absolute_uri("/").rstrip("/")
         count = 0
         for match in matches:
+            # A new broadcast needs a scheduled datetime to insert; an existing
+            # one always needs syncing, to push updated title/thumbnail/schedule.
+            if not match.external_identifier and match.get_datetime(ZoneInfo("UTC")) is None:
+                continue
             sync_live_stream.s(match.pk, base_url=base_url).apply_async()
             count += 1
 

--- a/tournamentcontrol/competition/tests/test_competition_admin.py
+++ b/tournamentcontrol/competition/tests/test_competition_admin.py
@@ -2638,6 +2638,18 @@ class BackendTests(MessagesTestMixin, TestCase):
             time=time(15, 0),
             datetime=datetime(2025, 5, 1, 5, 0, tzinfo=ZoneInfo("UTC")),
         )
+        # Marked live_stream but never actually broadcast (e.g. toggled via the
+        # bulk view before sync_live_stream was wired up to it) -- this is the
+        # create half of create-or-update, so it must still be queued.
+        never_broadcast = factories.MatchFactory.create(
+            stage=stage,
+            play_at=camera_ground,
+            live_stream=True,
+            external_identifier=None,
+            date=date(2025, 5, 1),
+            time=time(16, 0),
+            datetime=datetime(2025, 5, 1, 6, 0, tzinfo=ZoneInfo("UTC")),
+        )
         # Not streaming -- must be skipped.
         factories.MatchFactory.create(
             stage=stage,
@@ -2645,18 +2657,22 @@ class BackendTests(MessagesTestMixin, TestCase):
             live_stream=False,
             external_identifier=None,
             date=date(2025, 5, 1),
-            time=time(16, 0),
-            datetime=datetime(2025, 5, 1, 6, 0, tzinfo=ZoneInfo("UTC")),
+            time=time(17, 0),
+            datetime=datetime(2025, 5, 1, 7, 0, tzinfo=ZoneInfo("UTC")),
         )
-        # Marked live_stream but never actually broadcast -- must be skipped.
+        # Marked live_stream, never broadcast, AND no scheduled datetime --
+        # there's nothing to insert yet, so this must still be skipped. A
+        # distinct round keeps get_datetime() from borrowing a sibling
+        # match's datetime in the same stage/round.
         factories.MatchFactory.create(
             stage=stage,
             play_at=camera_ground,
             live_stream=True,
             external_identifier=None,
             date=date(2025, 5, 1),
-            time=time(17, 0),
-            datetime=datetime(2025, 5, 1, 7, 0, tzinfo=ZoneInfo("UTC")),
+            time=None,
+            datetime=None,
+            round=99,
         )
         season = stage.division.season
 
@@ -2670,9 +2686,12 @@ class BackendTests(MessagesTestMixin, TestCase):
         self.response_302()
 
         queued_pks = {call.args[0] for call in mock_sync_live_stream.s.call_args_list}
-        self.assertEqual(queued_pks, {streaming_match_1.pk, streaming_match_2.pk})
         self.assertEqual(
-            mock_sync_live_stream.s.return_value.apply_async.call_count, 2
+            queued_pks,
+            {streaming_match_1.pk, streaming_match_2.pk, never_broadcast.pk},
+        )
+        self.assertEqual(
+            mock_sync_live_stream.s.return_value.apply_async.call_count, 3
         )
 
     @patch("tournamentcontrol.competition.admin.sync_live_stream")


### PR DESCRIPTION
## Summary
Fixes a bug in #302's "Resync All" action: it required `external_identifier` to already be set, which excluded exactly the matches that most needed resyncing -- ones marked `live_stream=True` via the bulk toggle before `sync_live_stream` was wired up to it (the bug #302 itself fixed), and therefore never got a broadcast created. Reported after deploying #302: clicking "Resync All" returned "No currently-streaming matches to resync" despite matches genuinely needing one.

`sync_live_stream`/`_apply_sync` already implements correct create-or-update semantics keyed on `external_identifier` -- the bug was purely in this view's queryset excluding the create case. Now includes all `live_stream=True` matches on camera-equipped fields for the day, gated only on having a scheduled datetime when there's no broadcast yet (mirroring `match_live_stream`'s own `post_save_callback` gate).

## Test plan
- [ ] Updated unit test covers: existing-broadcast matches (update), never-broadcast-but-scheduled matches (create -- the actual bug), not-streaming matches (skip), and never-broadcast-with-no-scheduled-time matches (skip, nothing to insert yet).
- [ ] Full Django test matrix for regressions.

https://claude.ai/code/session_019Dw3AzDNFQp9vggdwAw8DA