### PR TITLE
Add adhoc live stream events for competition seasons

### DIFF
--- a/tournamentcontrol/competition/admin.py
+++ b/tournamentcontrol/competition/admin.py
@@ -52,6 +52,7 @@ from tournamentcontrol.competition.forms import (
     DrawGenerationMatchFormSet,
     GroundForm,
     LiveStreamEventForm,
+    LiveStreamKeyForm,
     MatchEditForm,
     MatchLiveStreamFormSet,
     MatchRefereeForm,
@@ -85,6 +86,7 @@ from tournamentcontrol.competition.models import (
     LadderEntry,
     LadderSummary,
     LiveStreamEvent,
+    LiveStreamKey,
     Match,
     MatchScoreSheet,
     Person,
@@ -106,6 +108,7 @@ from tournamentcontrol.competition.models import (
 from tournamentcontrol.competition.sites import CompetitionAdminMixin
 from tournamentcontrol.competition.tasks import (
     delete_youtube_broadcast,
+    delete_youtube_stream,
     generate_pdf_grid,
     generate_pdf_scorecards,
     sync_live_stream,
@@ -261,6 +264,15 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
                 path("add/", self.edit_livestreamevent, name="add"),
                 path("<int:pk>/", self.edit_livestreamevent, name="edit"),
                 path("<int:pk>/delete/", self.delete_livestreamevent, name="delete"),
+            ],
+            self.app_name,
+        )
+
+        livestreamkey_urls = (
+            [
+                path("add/", self.edit_livestreamkey, name="add"),
+                path("<int:pk>/", self.edit_livestreamkey, name="edit"),
+                path("<int:pk>/delete/", self.delete_livestreamkey, name="delete"),
             ],
             self.app_name,
         )
@@ -435,6 +447,10 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
                 path(
                     "<int:season_id>/live-stream-event/",
                     include(livestreamevent_urls, namespace="livestreamevent"),
+                ),
+                path(
+                    "<int:season_id>/stream-key/",
+                    include(livestreamkey_urls, namespace="livestreamkey"),
                 ),
                 path("<int:season_id>/permission/", self.perms_season, name="perms"),
                 path("<int:season_id>/venue/", include(venue_urls, namespace="venue")),
@@ -882,10 +898,11 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
             "timeslots",
             "referees",
         )
-        # Adhoc live stream events are only relevant when the season is
-        # being live streamed, keep the tab hidden otherwise.
+        # Adhoc live stream events and their managed stream keys are only
+        # relevant when the season is being live streamed, keep the tabs
+        # hidden otherwise.
         if season.live_stream:
-            related += ("live_stream_events",)
+            related += ("live_stream_events", "live_stream_keys")
 
         return self.generic_edit(
             request,
@@ -1586,6 +1603,7 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
             request,
             season.live_stream_events,
             instance=instance,
+            related=(),
             form_class=LiveStreamEventForm,
             always_save=season.live_stream,
             post_save_callback=post_save_callback,
@@ -1614,12 +1632,113 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
         # If the event was deleted while its broadcast was still scheduled,
         # clean up the orphaned broadcast on the YouTube platform too.
         if (
-            response.status_code == 302
-            and external_identifier
+            external_identifier
             and season.live_stream_client_id
             and season.live_stream_client_secret
+            and not season.live_stream_events.filter(pk=pk).exists()
         ):
             delete_youtube_broadcast.s(season.pk, external_identifier).apply_async()
+        return response
+
+    @competition_by_pk_m
+    @staff_login_required_m
+    def edit_livestreamkey(self, request, season, extra_context, pk=None, **kwargs):
+        if pk is None:
+            instance = LiveStreamKey(season=season)
+        else:
+            instance = get_object_or_404(season.live_stream_keys, pk=pk)
+
+        def pre_save_callback(obj: LiveStreamKey):
+            # We can't interact with the YouTube API without credentials;
+            # keep the record but let the user know no key was generated.
+            if not (season.live_stream_client_id and season.live_stream_client_secret):
+                messages.warning(
+                    request,
+                    _(
+                        "YouTube credentials are not configured for this "
+                        "season; no stream key has been generated."
+                    ),
+                )
+                return
+
+            body = {
+                "snippet": {
+                    "title": f"{season.competition} {season} ({obj.title})",
+                },
+                "cdn": {
+                    "ingestionType": "rtmp",
+                    "frameRate": "variable",
+                    "resolution": "variable",
+                },
+            }
+
+            try:
+                if obj.external_identifier:
+                    body["id"] = obj.external_identifier
+                    stream = (
+                        season.youtube.liveStreams()
+                        .update(part="snippet,cdn", body=body)
+                        .execute()
+                    )
+                    log.info("YouTube stream %(id)r updated", stream)
+                else:
+                    stream = (
+                        season.youtube.liveStreams()
+                        .insert(part="snippet,cdn", body=body)
+                        .execute()
+                    )
+                    obj.external_identifier = stream["id"]
+                    log.info("YouTube stream %(id)r inserted", stream)
+
+                obj.stream_key = stream["cdn"]["ingestionInfo"]["streamName"]
+
+            except HttpError as exc:
+                messages.error(request, exc.reason)
+                return self.redirect(".")
+
+        return self.generic_edit(
+            request,
+            season.live_stream_keys,
+            instance=instance,
+            # The reverse relation to events must not be enumerated as
+            # related tabs — there is no nested namespace routed for it.
+            related=(),
+            form_class=LiveStreamKeyForm,
+            always_save=season.live_stream,
+            pre_save_callback=pre_save_callback,
+            post_save_redirect=self.redirect(
+                season.urls["edit"] + "#live_stream_keys-tab"
+            ),
+            permission_required=True,
+            extra_context=extra_context,
+        )
+
+    @competition_by_pk_m
+    @staff_login_required_m
+    def delete_livestreamkey(self, request, season, pk, **kwargs):
+        stream = get_object_or_404(season.live_stream_keys, pk=pk)
+        external_identifier = stream.external_identifier
+        post_delete_redirect = self.redirect(
+            season.urls["edit"] + "#live_stream_keys-tab"
+        )
+        response = self.generic_delete(
+            request,
+            season.live_stream_keys,
+            pk=pk,
+            permission_required=True,
+            post_delete_redirect=post_delete_redirect,
+        )
+        # If the record was deleted while its liveStream still existed on
+        # the YouTube platform, clean that up too. Deletion can be refused
+        # (ProtectedError when events still use this key) so check the row
+        # really has gone before queueing.
+        if (
+            external_identifier
+            and season.live_stream_client_id
+            and season.live_stream_client_secret
+            and not season.live_stream_keys.filter(pk=pk).exists()
+        ):
+            delete_youtube_stream.s(season.pk, external_identifier).apply_async()
         return response
 
     @competition_by_pk_m

--- a/tournamentcontrol/competition/admin.py
+++ b/tournamentcontrol/competition/admin.py
@@ -51,6 +51,7 @@ from tournamentcontrol.competition.forms import (
     DrawGenerationFormSet,
     DrawGenerationMatchFormSet,
     GroundForm,
+    LiveStreamEventForm,
     MatchEditForm,
     MatchLiveStreamFormSet,
     MatchRefereeForm,
@@ -83,6 +84,7 @@ from tournamentcontrol.competition.models import (
     Ground,
     LadderEntry,
     LadderSummary,
+    LiveStreamEvent,
     Match,
     MatchScoreSheet,
     Person,
@@ -103,9 +105,11 @@ from tournamentcontrol.competition.models import (
 )
 from tournamentcontrol.competition.sites import CompetitionAdminMixin
 from tournamentcontrol.competition.tasks import (
+    delete_youtube_broadcast,
     generate_pdf_grid,
     generate_pdf_scorecards,
     sync_live_stream,
+    sync_live_stream_event,
 )
 from tournamentcontrol.competition.utils import (
     FauxQueryset,
@@ -248,6 +252,15 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
                 path("add/", self.edit_seasonreferee, name="add"),
                 path("<int:pk>/", self.edit_seasonreferee, name="edit"),
                 path("<int:pk>/delete/", self.delete_seasonreferee, name="delete"),
+            ],
+            self.app_name,
+        )
+
+        livestreamevent_urls = (
+            [
+                path("add/", self.edit_livestreamevent, name="add"),
+                path("<int:pk>/", self.edit_livestreamevent, name="edit"),
+                path("<int:pk>/delete/", self.delete_livestreamevent, name="delete"),
             ],
             self.app_name,
         )
@@ -418,6 +431,10 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
                 path(
                     "<int:season_id>/referees/",
                     include(referees_urls, namespace="seasonreferee"),
+                ),
+                path(
+                    "<int:season_id>/live-stream-event/",
+                    include(livestreamevent_urls, namespace="livestreamevent"),
                 ),
                 path("<int:season_id>/permission/", self.perms_season, name="perms"),
                 path("<int:season_id>/venue/", include(venue_urls, namespace="venue")),
@@ -858,17 +875,23 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
 
         extra_context.setdefault("dates", dates)
 
+        related = (
+            "exclusions",
+            "divisions",
+            "venues",
+            "timeslots",
+            "referees",
+        )
+        # Adhoc live stream events are only relevant when the season is
+        # being live streamed, keep the tab hidden otherwise.
+        if season.live_stream:
+            related += ("live_stream_events",)
+
         return self.generic_edit(
             request,
             Season,
             instance=season,
-            related=(
-                "exclusions",
-                "divisions",
-                "venues",
-                "timeslots",
-                "referees",
-            ),
+            related=related,
             form_class=SeasonForm,
             form_kwargs={"user": request.user},
             post_save_redirect=self.redirect(competition.urls["edit"]),
@@ -1538,6 +1561,66 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
             permission_required=True,
             post_delete_redirect=post_delete_redirect,
         )
+
+    @competition_by_pk_m
+    @staff_login_required_m
+    def edit_livestreamevent(self, request, season, extra_context, pk=None, **kwargs):
+        if pk is None:
+            instance = LiveStreamEvent(season=season)
+        else:
+            instance = get_object_or_404(season.live_stream_events, pk=pk)
+
+        def post_save_callback(obj: LiveStreamEvent):
+            # Check if YouTube credentials are configured before queuing
+            # anything, we can't interact with the YouTube API without them.
+            if not (season.live_stream_client_id and season.live_stream_client_secret):
+                return None
+            # A brand new event which is not to be streamed requires no sync;
+            # an existing broadcast always does (update or delete).
+            if not obj.external_identifier and not obj.live_stream:
+                return None
+            sync_live_stream_event.s(obj.pk).apply_async()
+            return None
+
+        return self.generic_edit(
+            request,
+            season.live_stream_events,
+            instance=instance,
+            form_class=LiveStreamEventForm,
+            always_save=season.live_stream,
+            post_save_callback=post_save_callback,
+            post_save_redirect=self.redirect(
+                season.urls["edit"] + "#live_stream_events-tab"
+            ),
+            permission_required=True,
+            extra_context=extra_context,
+        )
+
+    @competition_by_pk_m
+    @staff_login_required_m
+    def delete_livestreamevent(self, request, season, pk, **kwargs):
+        event = get_object_or_404(season.live_stream_events, pk=pk)
+        external_identifier = event.external_identifier
+        post_delete_redirect = self.redirect(
+            season.urls["edit"] + "#live_stream_events-tab"
+        )
+        response = self.generic_delete(
+            request,
+            season.live_stream_events,
+            pk=pk,
+            permission_required=True,
+            post_delete_redirect=post_delete_redirect,
+        )
+        # If the event was deleted while its broadcast was still scheduled,
+        # clean up the orphaned broadcast on the YouTube platform too.
+        if (
+            response.status_code == 302
+            and external_identifier
+            and season.live_stream_client_id
+            and season.live_stream_client_secret
+        ):
+            delete_youtube_broadcast.s(season.pk, external_identifier).apply_async()
+        return response
 
     @competition_by_pk_m
     @staff_login_required_m

--- a/tournamentcontrol/competition/admin.py
+++ b/tournamentcontrol/competition/admin.py
@@ -107,8 +107,7 @@ from tournamentcontrol.competition.models import (
 )
 from tournamentcontrol.competition.sites import CompetitionAdminMixin
 from tournamentcontrol.competition.tasks import (
-    delete_youtube_broadcast,
-    delete_youtube_stream,
+    build_live_stream_event_body,
     generate_pdf_grid,
     generate_pdf_scorecards,
     sync_live_stream,
@@ -261,18 +260,22 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
 
         livestreamevent_urls = (
             [
+                # The primary key is the YouTube broadcast identifier, so
+                # these routes match strings rather than integers.
                 path("add/", self.edit_livestreamevent, name="add"),
-                path("<int:pk>/", self.edit_livestreamevent, name="edit"),
-                path("<int:pk>/delete/", self.delete_livestreamevent, name="delete"),
+                path("<str:pk>/", self.edit_livestreamevent, name="edit"),
+                path("<str:pk>/delete/", self.delete_livestreamevent, name="delete"),
             ],
             self.app_name,
         )
 
         livestreamkey_urls = (
             [
+                # The primary key is the YouTube liveStream identifier, so
+                # these routes match strings rather than integers.
                 path("add/", self.edit_livestreamkey, name="add"),
-                path("<int:pk>/", self.edit_livestreamkey, name="edit"),
-                path("<int:pk>/delete/", self.delete_livestreamkey, name="delete"),
+                path("<str:pk>/", self.edit_livestreamkey, name="edit"),
+                path("<str:pk>/delete/", self.delete_livestreamkey, name="delete"),
             ],
             self.app_name,
         )
@@ -1587,14 +1590,42 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
         else:
             instance = get_object_or_404(season.live_stream_events, pk=pk)
 
+        def pre_save_callback(obj: LiveStreamEvent):
+            # The broadcast identifier is the primary key, so a new event
+            # must create its broadcast on the YouTube platform up front.
+            if obj.pk:
+                return
+
+            if not (season.live_stream_client_id and season.live_stream_client_secret):
+                messages.error(
+                    request,
+                    _(
+                        "YouTube credentials must be configured for this "
+                        "season before live stream events can be created."
+                    ),
+                )
+                return self.redirect(".")
+
+            try:
+                broadcast = (
+                    season.youtube.liveBroadcasts()
+                    .insert(
+                        part="id,snippet,status,contentDetails",
+                        body=build_live_stream_event_body(obj),
+                    )
+                    .execute()
+                )
+            except HttpError as exc:
+                messages.error(request, exc.reason)
+                return self.redirect(".")
+
+            obj.external_identifier = broadcast["id"]
+            log.info("YouTube video %(id)r inserted", broadcast)
+
         def post_save_callback(obj: LiveStreamEvent):
             # Check if YouTube credentials are configured before queuing
             # anything, we can't interact with the YouTube API without them.
             if not (season.live_stream_client_id and season.live_stream_client_secret):
-                return None
-            # A brand new event which is not to be streamed requires no sync;
-            # an existing broadcast always does (update or delete).
-            if not obj.external_identifier and not obj.live_stream:
                 return None
             sync_live_stream_event.s(obj.pk).apply_async()
             return None
@@ -1606,6 +1637,7 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
             related=(),
             form_class=LiveStreamEventForm,
             always_save=season.live_stream,
+            pre_save_callback=pre_save_callback,
             post_save_callback=post_save_callback,
             post_save_redirect=self.redirect(
                 season.urls["edit"] + "#live_stream_events-tab"
@@ -1617,28 +1649,18 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
     @competition_by_pk_m
     @staff_login_required_m
     def delete_livestreamevent(self, request, season, pk, **kwargs):
-        event = get_object_or_404(season.live_stream_events, pk=pk)
-        external_identifier = event.external_identifier
+        # Removal of the broadcast from the YouTube platform is handled by
+        # the post_delete signal on the model.
         post_delete_redirect = self.redirect(
             season.urls["edit"] + "#live_stream_events-tab"
         )
-        response = self.generic_delete(
+        return self.generic_delete(
             request,
             season.live_stream_events,
             pk=pk,
             permission_required=True,
             post_delete_redirect=post_delete_redirect,
         )
-        # If the event was deleted while its broadcast was still scheduled,
-        # clean up the orphaned broadcast on the YouTube platform too.
-        if (
-            external_identifier
-            and season.live_stream_client_id
-            and season.live_stream_client_secret
-            and not season.live_stream_events.filter(pk=pk).exists()
-        ):
-            delete_youtube_broadcast.s(season.pk, external_identifier).apply_async()
-        return response
 
     @competition_by_pk_m
     @staff_login_required_m
@@ -1649,14 +1671,26 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
             instance = get_object_or_404(season.live_stream_keys, pk=pk)
 
         def pre_save_callback(obj: LiveStreamKey):
-            # We can't interact with the YouTube API without credentials;
-            # keep the record but let the user know no key was generated.
+            # The liveStream identifier is the primary key, so a new record
+            # must generate its stream on the YouTube platform up front. For
+            # an existing record the platform update is cosmetic, so missing
+            # credentials only warrant a warning.
             if not (season.live_stream_client_id and season.live_stream_client_secret):
+                if not obj.pk:
+                    messages.error(
+                        request,
+                        _(
+                            "YouTube credentials must be configured for this "
+                            "season before stream keys can be generated."
+                        ),
+                    )
+                    return self.redirect(".")
                 messages.warning(
                     request,
                     _(
                         "YouTube credentials are not configured for this "
-                        "season; no stream key has been generated."
+                        "season; the stream title was not updated on the "
+                        "platform."
                     ),
                 )
                 return
@@ -1716,30 +1750,18 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
     @competition_by_pk_m
     @staff_login_required_m
     def delete_livestreamkey(self, request, season, pk, **kwargs):
-        stream = get_object_or_404(season.live_stream_keys, pk=pk)
-        external_identifier = stream.external_identifier
+        # Removal of the liveStream from the YouTube platform is handled by
+        # the post_delete signal on the model.
         post_delete_redirect = self.redirect(
             season.urls["edit"] + "#live_stream_keys-tab"
         )
-        response = self.generic_delete(
+        return self.generic_delete(
             request,
             season.live_stream_keys,
             pk=pk,
             permission_required=True,
             post_delete_redirect=post_delete_redirect,
         )
-        # If the record was deleted while its liveStream still existed on
-        # the YouTube platform, clean that up too. Deletion can be refused
-        # (ProtectedError when events still use this key) so check the row
-        # really has gone before queueing.
-        if (
-            external_identifier
-            and season.live_stream_client_id
-            and season.live_stream_client_secret
-            and not season.live_stream_keys.filter(pk=pk).exists()
-        ):
-            delete_youtube_stream.s(season.pk, external_identifier).apply_async()
-        return response
 
     @competition_by_pk_m
     @staff_login_required_m

--- a/tournamentcontrol/competition/admin.py
+++ b/tournamentcontrol/competition/admin.py
@@ -23,12 +23,14 @@ from django.urls import include, path, re_path, reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _, ngettext
 from googleapiclient.errors import HttpError
+from guardian.utils import get_40x_or_None
 
 from touchtechnology.admin.base import AdminComponent
 from touchtechnology.common.decorators import (
     csrf_exempt_m,
     staff_login_required_m,
 )
+from touchtechnology.common.utils import get_perms_for_model
 from touchtechnology.common.prince import prince
 from tournamentcontrol.competition.dashboard import (
     BasicResultWidget,
@@ -1646,14 +1648,74 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
             extra_context=extra_context,
         )
 
+    def _confirm_youtube_destroyed(
+        self, request, season, instance, collection_name, redirect_response
+    ):
+        """
+        Guard local deletion of a record backed by a YouTube resource.
+
+        The record must not be removed from the database while its resource
+        may still exist on the platform — that would leave clutter we have
+        no way of removing. Destroy the resource first; a 404 means it is
+        already gone, which is equally confirmation.
+
+        Returns None when destruction is confirmed, otherwise the
+        HttpResponse to return instead of deleting.
+        """
+        # Mirror the permission check performed by generic_delete so the
+        # platform is never touched on behalf of a user who is not entitled
+        # to delete the record locally.
+        has_permission = get_40x_or_None(
+            request,
+            get_perms_for_model(type(instance), delete=True),
+            obj=instance,
+            return_403=not request.user.is_anonymous,
+            accept_global_perms=True,
+        )
+        if has_permission is not None:
+            return has_permission
+
+        verbose_name = instance._meta.verbose_name
+
+        if not (season.live_stream_client_id and season.live_stream_client_secret):
+            messages.error(
+                request,
+                _(
+                    "YouTube credentials are not configured for this season; "
+                    "unable to confirm the %s has been removed from the "
+                    "platform."
+                )
+                % verbose_name,
+            )
+            return redirect_response
+
+        try:
+            getattr(season.youtube, collection_name)().delete(
+                id=instance.pk
+            ).execute()
+            log.info("YouTube resource %r deleted", instance.pk)
+        except HttpError as exc:
+            if getattr(exc.resp, "status", None) != 404:
+                messages.error(request, exc.reason)
+                return redirect_response
+            # Already absent from the platform — confirmed destroyed.
+            log.info("YouTube resource %r already deleted", instance.pk)
+
+        return None
+
     @competition_by_pk_m
     @staff_login_required_m
     def delete_livestreamevent(self, request, season, pk, **kwargs):
-        # Removal of the broadcast from the YouTube platform is handled by
-        # the post_delete signal on the model.
         post_delete_redirect = self.redirect(
             season.urls["edit"] + "#live_stream_events-tab"
         )
+        if request.method == "POST":
+            event = get_object_or_404(season.live_stream_events, pk=pk)
+            blocked = self._confirm_youtube_destroyed(
+                request, season, event, "liveBroadcasts", post_delete_redirect
+            )
+            if blocked is not None:
+                return blocked
         return self.generic_delete(
             request,
             season.live_stream_events,
@@ -1750,11 +1812,19 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
     @competition_by_pk_m
     @staff_login_required_m
     def delete_livestreamkey(self, request, season, pk, **kwargs):
-        # Removal of the liveStream from the YouTube platform is handled by
-        # the post_delete signal on the model.
         post_delete_redirect = self.redirect(
             season.urls["edit"] + "#live_stream_keys-tab"
         )
+        if request.method == "POST":
+            stream_key = get_object_or_404(season.live_stream_keys, pk=pk)
+            # A key still referenced by events is protected — let
+            # generic_delete refuse it without touching the platform.
+            if not stream_key.live_stream_events.exists():
+                blocked = self._confirm_youtube_destroyed(
+                    request, season, stream_key, "liveStreams", post_delete_redirect
+                )
+                if blocked is not None:
+                    return blocked
         return self.generic_delete(
             request,
             season.live_stream_keys,

--- a/tournamentcontrol/competition/apps.py
+++ b/tournamentcontrol/competition/apps.py
@@ -29,6 +29,8 @@ class CompetitionConfig(AppConfig):
             Ground,
             LadderEntry,
             LadderSummary,
+            LiveStreamEvent,
+            LiveStreamKey,
             Match,
             Season,
             Stage,
@@ -51,6 +53,14 @@ class CompetitionConfig(AppConfig):
             update_match_datetimes_on_place_timezone_change,
         )
 
+        # Imported from the submodule rather than the signals package to
+        # avoid a circular import: models imports the signals package, and
+        # these handlers import tasks which imports models.
+        from tournamentcontrol.competition.signals.live_streams import (
+            cleanup_youtube_broadcast,
+            cleanup_youtube_stream,
+        )
+
         site.register(CompetitionAdminComponent)
 
         post_save.connect(match_saved_handler, sender=Match)
@@ -61,6 +71,10 @@ class CompetitionConfig(AppConfig):
 
         post_save.connect(set_ground_latlng, sender=Ground)
         post_save.connect(set_ground_timezone, sender=Ground)
+
+        # Remove YouTube platform resources when their local records go away
+        post_delete.connect(cleanup_youtube_broadcast, sender=LiveStreamEvent)
+        post_delete.connect(cleanup_youtube_stream, sender=LiveStreamKey)
 
         # Capture timezone before save to detect changes
         pre_save.connect(capture_timezone_before_save, sender=Venue)

--- a/tournamentcontrol/competition/forms.py
+++ b/tournamentcontrol/competition/forms.py
@@ -1440,6 +1440,11 @@ class LiveStreamEventForm(BootstrapFormControlMixin, ModelForm):
         # offer the season's own managed pool, never the ground keys used
         # for match streaming.
         self.fields["stream_key"].queryset = self.instance.season.live_stream_keys
+        # A new event always creates its broadcast — the platform identifier
+        # is the primary key — so the removal toggle only applies once the
+        # event exists.
+        if not self.instance.pk:
+            self.fields.pop("live_stream")
 
 
 class MatchScheduleForm(BaseMatchFormMixin, ModelForm):

--- a/tournamentcontrol/competition/forms.py
+++ b/tournamentcontrol/competition/forms.py
@@ -72,6 +72,7 @@ from tournamentcontrol.competition.models import (
     DrawFormat,
     Ground,
     LadderEntry,
+    LiveStreamEvent,
     Match,
     Person,
     Place,
@@ -1399,6 +1400,42 @@ class MatchLiveStreamForm(BootstrapFormControlMixin, ModelForm):
 
 
 MatchLiveStreamFormSet = modelformset_factory(Match, extra=0, form=MatchLiveStreamForm)
+
+
+class LiveStreamEventForm(BootstrapFormControlMixin, ModelForm):
+    class Meta:
+        model = LiveStreamEvent
+        fields = (
+            "title",
+            "description",
+            "start",
+            "stop",
+            "ground",
+            "live_stream",
+            "live_stream_thumbnail_image",
+        )
+        labels = {
+            "ground": _("Stream"),
+            "live_stream_thumbnail_image": _("Video Thumbnail"),
+        }
+        help_texts = {
+            "live_stream_thumbnail_image": _(
+                "Upload a custom thumbnail for this event. "
+                "If not set, the season's default thumbnail will be used."
+            ),
+        }
+        field_classes = {
+            "live_stream_thumbnail_image": ThumbnailImageField,
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Only offer streams (cameras) that belong to this season.
+        self.fields["ground"].queryset = (
+            Ground.objects.filter(venue__season=self.instance.season)
+            .select_related("venue")
+            .order_by("venue__order", "order")
+        )
 
 
 class MatchScheduleForm(BaseMatchFormMixin, ModelForm):

--- a/tournamentcontrol/competition/forms.py
+++ b/tournamentcontrol/competition/forms.py
@@ -1410,12 +1410,11 @@ class LiveStreamEventForm(BootstrapFormControlMixin, ModelForm):
             "description",
             "start",
             "stop",
-            "ground",
+            "stream_key",
             "live_stream",
             "live_stream_thumbnail_image",
         )
         labels = {
-            "ground": _("Stream"),
             "live_stream_thumbnail_image": _("Video Thumbnail"),
         }
         help_texts = {
@@ -1427,15 +1426,6 @@ class LiveStreamEventForm(BootstrapFormControlMixin, ModelForm):
         field_classes = {
             "live_stream_thumbnail_image": ThumbnailImageField,
         }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Only offer streams (cameras) that belong to this season.
-        self.fields["ground"].queryset = (
-            Ground.objects.filter(venue__season=self.instance.season)
-            .select_related("venue")
-            .order_by("venue__order", "order")
-        )
 
 
 class MatchScheduleForm(BaseMatchFormMixin, ModelForm):

--- a/tournamentcontrol/competition/forms.py
+++ b/tournamentcontrol/competition/forms.py
@@ -73,6 +73,7 @@ from tournamentcontrol.competition.models import (
     Ground,
     LadderEntry,
     LiveStreamEvent,
+    LiveStreamKey,
     Match,
     Person,
     Place,
@@ -1402,6 +1403,12 @@ class MatchLiveStreamForm(BootstrapFormControlMixin, ModelForm):
 MatchLiveStreamFormSet = modelformset_factory(Match, extra=0, form=MatchLiveStreamForm)
 
 
+class LiveStreamKeyForm(BootstrapFormControlMixin, ModelForm):
+    class Meta:
+        model = LiveStreamKey
+        fields = ("title",)
+
+
 class LiveStreamEventForm(BootstrapFormControlMixin, ModelForm):
     class Meta:
         model = LiveStreamEvent
@@ -1426,6 +1433,13 @@ class LiveStreamEventForm(BootstrapFormControlMixin, ModelForm):
         field_classes = {
             "live_stream_thumbnail_image": ThumbnailImageField,
         }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Stream keys are a unique domain associated to the season — only
+        # offer the season's own managed pool, never the ground keys used
+        # for match streaming.
+        self.fields["stream_key"].queryset = self.instance.season.live_stream_keys
 
 
 class MatchScheduleForm(BaseMatchFormMixin, ModelForm):

--- a/tournamentcontrol/competition/migrations/0061_live_stream_event.py
+++ b/tournamentcontrol/competition/migrations/0061_live_stream_event.py
@@ -1,0 +1,124 @@
+# Add adhoc live stream events associated with a competition Season.
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+import touchtechnology.common.db.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("competition", "0060_season_enable_experimental_views"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="LiveStreamEvent",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "title",
+                    models.CharField(
+                        help_text="Title of the broadcast on the YouTube platform.",
+                        max_length=100,
+                    ),
+                ),
+                (
+                    "description",
+                    models.TextField(
+                        blank=True,
+                        help_text="Description of the broadcast on the YouTube platform.",
+                    ),
+                ),
+                (
+                    "start",
+                    touchtechnology.common.db.models.DateTimeField(
+                        help_text="When the live stream is scheduled to commence.",
+                        verbose_name="Scheduled start",
+                    ),
+                ),
+                (
+                    "stop",
+                    touchtechnology.common.db.models.DateTimeField(
+                        help_text="When the live stream is scheduled to conclude.",
+                        verbose_name="Scheduled finish",
+                    ),
+                ),
+                (
+                    "live_stream",
+                    touchtechnology.common.db.models.BooleanField(
+                        default=True,
+                        help_text=(
+                            "Set to No to remove the scheduled broadcast from the "
+                            "YouTube platform while keeping this event for your "
+                            "records."
+                        ),
+                    ),
+                ),
+                (
+                    "external_identifier",
+                    models.CharField(
+                        blank=True,
+                        db_index=True,
+                        max_length=20,
+                        null=True,
+                        unique=True,
+                    ),
+                ),
+                (
+                    "live_stream_bind",
+                    models.CharField(
+                        blank=True, db_index=True, max_length=50, null=True
+                    ),
+                ),
+                (
+                    "live_stream_thumbnail_image",
+                    models.BinaryField(
+                        blank=True,
+                        editable=True,
+                        help_text=(
+                            "Image to be used as thumbnail image on the YouTube "
+                            "platform"
+                        ),
+                        null=True,
+                    ),
+                ),
+                (
+                    "ground",
+                    touchtechnology.common.db.models.ForeignKey(
+                        blank=True,
+                        help_text=(
+                            "The stream (camera) that will broadcast this event — "
+                            "the broadcast will be bound to this ground's stream "
+                            "key."
+                        ),
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="live_stream_events",
+                        to="competition.ground",
+                    ),
+                ),
+                (
+                    "season",
+                    touchtechnology.common.db.models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="live_stream_events",
+                        to="competition.season",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ("start", "title"),
+                "verbose_name": "live stream event",
+            },
+        ),
+    ]

--- a/tournamentcontrol/competition/migrations/0061_live_stream_event.py
+++ b/tournamentcontrol/competition/migrations/0061_live_stream_event.py
@@ -2,7 +2,9 @@
 # competition Season.
 #
 # Standalone feature: this migration only creates new tables, it does not
-# alter any existing schema.
+# alter any existing schema. Both models use the identifier issued by the
+# YouTube platform as their primary key — those identifiers are globally
+# unique and never reused.
 
 import django.db.models.deletion
 from django.db import migrations, models
@@ -21,15 +23,6 @@ class Migration(migrations.Migration):
             name="LiveStreamKey",
             fields=[
                 (
-                    "id",
-                    models.AutoField(
-                        auto_created=True,
-                        primary_key=True,
-                        serialize=False,
-                        verbose_name="ID",
-                    ),
-                ),
-                (
                     "title",
                     models.CharField(
                         help_text=(
@@ -42,22 +35,12 @@ class Migration(migrations.Migration):
                 (
                     "external_identifier",
                     models.CharField(
-                        blank=True,
-                        db_index=True,
-                        max_length=50,
-                        null=True,
-                        unique=True,
+                        max_length=50, primary_key=True, serialize=False
                     ),
                 ),
                 (
                     "stream_key",
-                    models.CharField(
-                        blank=True,
-                        db_index=True,
-                        max_length=50,
-                        null=True,
-                        unique=True,
-                    ),
+                    models.CharField(db_index=True, max_length=50, unique=True),
                 ),
                 (
                     "season",
@@ -76,15 +59,6 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name="LiveStreamEvent",
             fields=[
-                (
-                    "id",
-                    models.AutoField(
-                        auto_created=True,
-                        primary_key=True,
-                        serialize=False,
-                        verbose_name="ID",
-                    ),
-                ),
                 (
                     "title",
                     models.CharField(
@@ -120,18 +94,15 @@ class Migration(migrations.Migration):
                         help_text=(
                             "Set to No to remove the scheduled broadcast from the "
                             "YouTube platform while keeping this event for your "
-                            "records."
+                            "records. The broadcast cannot be reinstated once "
+                            "removed."
                         ),
                     ),
                 ),
                 (
                     "external_identifier",
                     models.CharField(
-                        blank=True,
-                        db_index=True,
-                        max_length=20,
-                        null=True,
-                        unique=True,
+                        max_length=20, primary_key=True, serialize=False
                     ),
                 ),
                 (

--- a/tournamentcontrol/competition/migrations/0061_live_stream_event.py
+++ b/tournamentcontrol/competition/migrations/0061_live_stream_event.py
@@ -1,4 +1,7 @@
 # Add adhoc live stream events associated with a competition Season.
+#
+# Standalone feature: this migration only creates the new table, it does not
+# alter any existing schema.
 
 import django.db.models.deletion
 from django.db import migrations, models
@@ -65,6 +68,18 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 (
+                    "stream_key",
+                    models.CharField(
+                        blank=True,
+                        help_text=(
+                            "The stream key the camera or encoder operator should "
+                            "use to deliver video for this event."
+                        ),
+                        max_length=50,
+                        null=True,
+                    ),
+                ),
+                (
                     "external_identifier",
                     models.CharField(
                         blank=True,
@@ -72,12 +87,6 @@ class Migration(migrations.Migration):
                         max_length=20,
                         null=True,
                         unique=True,
-                    ),
-                ),
-                (
-                    "live_stream_bind",
-                    models.CharField(
-                        blank=True, db_index=True, max_length=50, null=True
                     ),
                 ),
                 (
@@ -90,21 +99,6 @@ class Migration(migrations.Migration):
                             "platform"
                         ),
                         null=True,
-                    ),
-                ),
-                (
-                    "ground",
-                    touchtechnology.common.db.models.ForeignKey(
-                        blank=True,
-                        help_text=(
-                            "The stream (camera) that will broadcast this event — "
-                            "the broadcast will be bound to this ground's stream "
-                            "key."
-                        ),
-                        null=True,
-                        on_delete=django.db.models.deletion.SET_NULL,
-                        related_name="live_stream_events",
-                        to="competition.ground",
                     ),
                 ),
                 (

--- a/tournamentcontrol/competition/migrations/0061_live_stream_event.py
+++ b/tournamentcontrol/competition/migrations/0061_live_stream_event.py
@@ -1,6 +1,7 @@
-# Add adhoc live stream events associated with a competition Season.
+# Add adhoc live stream events and managed stream keys associated with a
+# competition Season.
 #
-# Standalone feature: this migration only creates the new table, it does not
+# Standalone feature: this migration only creates new tables, it does not
 # alter any existing schema.
 
 import django.db.models.deletion
@@ -16,6 +17,62 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.CreateModel(
+            name="LiveStreamKey",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "title",
+                    models.CharField(
+                        help_text=(
+                            "Identify this stream key — for example the camera or "
+                            "production position that will use it."
+                        ),
+                        max_length=100,
+                    ),
+                ),
+                (
+                    "external_identifier",
+                    models.CharField(
+                        blank=True,
+                        db_index=True,
+                        max_length=50,
+                        null=True,
+                        unique=True,
+                    ),
+                ),
+                (
+                    "stream_key",
+                    models.CharField(
+                        blank=True,
+                        db_index=True,
+                        max_length=50,
+                        null=True,
+                        unique=True,
+                    ),
+                ),
+                (
+                    "season",
+                    touchtechnology.common.db.models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="live_stream_keys",
+                        to="competition.season",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ("title", "pk"),
+                "verbose_name": "stream key",
+            },
+        ),
         migrations.CreateModel(
             name="LiveStreamEvent",
             fields=[
@@ -68,18 +125,6 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 (
-                    "stream_key",
-                    models.CharField(
-                        blank=True,
-                        help_text=(
-                            "The stream key the camera or encoder operator should "
-                            "use to deliver video for this event."
-                        ),
-                        max_length=50,
-                        null=True,
-                    ),
-                ),
-                (
                     "external_identifier",
                     models.CharField(
                         blank=True,
@@ -87,6 +132,12 @@ class Migration(migrations.Migration):
                         max_length=20,
                         null=True,
                         unique=True,
+                    ),
+                ),
+                (
+                    "live_stream_bind",
+                    models.CharField(
+                        blank=True, db_index=True, max_length=50, null=True
                     ),
                 ),
                 (
@@ -107,6 +158,20 @@ class Migration(migrations.Migration):
                         on_delete=django.db.models.deletion.CASCADE,
                         related_name="live_stream_events",
                         to="competition.season",
+                    ),
+                ),
+                (
+                    "stream_key",
+                    touchtechnology.common.db.models.ForeignKey(
+                        blank=True,
+                        help_text=(
+                            "The stream key the camera or encoder operator should "
+                            "use to deliver video for this event."
+                        ),
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="live_stream_events",
+                        to="competition.livestreamkey",
                     ),
                 ),
             ],

--- a/tournamentcontrol/competition/models.py
+++ b/tournamentcontrol/competition/models.py
@@ -550,9 +550,9 @@ class Season(AdminUrlMixin, OrderedSitemapNode):
         return {
             # live-stream thumbnail blobs are only needed by the thumbnail
             # views, never drag them out of the database for list views.
-            "live_stream_events": self.live_stream_events.select_related(
-                "ground"
-            ).defer("live_stream_thumbnail_image"),
+            "live_stream_events": self.live_stream_events.defer(
+                "live_stream_thumbnail_image"
+            ),
         }
 
     def __repr__(self):
@@ -1964,98 +1964,7 @@ class SeasonAssociation(AdminUrlMixin, models.Model):
         ]
 
 
-class LiveStreamTransitionMixin:
-    """
-    Shared YouTube ``liveBroadcasts.transition`` behaviour for models that
-    represent a broadcast (``Match`` and ``LiveStreamEvent``).
-
-    Concrete models must provide an ``external_identifier`` field holding the
-    YouTube broadcast identifier, and a ``_live_stream_season`` method
-    returning the ``Season`` whose OAuth2 credentials operate the channel.
-    """
-
-    def _live_stream_season(self):
-        raise NotImplementedError
-
-    def transition_live_stream(self, status, youtube_service=None):
-        """
-        Transition the live stream status of this broadcast.
-
-        Args:
-            status (str): The target broadcast status ('testing', 'live', 'complete')
-            youtube_service: Optional YouTube API service instance. If None, will use
-                           season's YouTube service.
-
-        Returns:
-            dict: Response from YouTube API
-
-        Raises:
-            LiveStreamIdentifierMissing: If there is no external_identifier
-            InvalidLiveStreamTransition: If the transition is invalid
-            LiveStreamTransitionWarning: Warning for potentially invalid transitions
-        """
-        verbose_name = self._meta.verbose_name
-
-        # Check for a live stream identifier
-        if not self.external_identifier:
-            raise LiveStreamIdentifierMissing(
-                f"{verbose_name.capitalize()} {self} does not have a live stream identifier"
-            )
-
-        # Define valid transitions
-        valid_transitions = {"testing": ["live"], "live": ["complete"], "complete": []}
-
-        # Get current broadcast status from YouTube if available
-        current_status = None
-        if youtube_service:
-            try:
-                response = (
-                    youtube_service.liveBroadcasts()
-                    .list(part="status", id=self.external_identifier)
-                    .execute()
-                )
-                if response.get("items"):
-                    current_status = response["items"][0]["status"]["lifeCycleStatus"]
-            except Exception:
-                # If we can't get current status, proceed anyway
-                pass
-
-        # Check for invalid transitions based on known current status
-        if current_status:
-            valid_next_states = valid_transitions.get(current_status, [])
-            if status not in valid_next_states and status != current_status:
-                if current_status == "complete":
-                    # Can't transition from complete to anything
-                    raise InvalidLiveStreamTransition(
-                        f"Cannot transition from '{current_status}' to '{status}' "
-                        f"for {verbose_name} {self}"
-                    )
-                else:
-                    # Issue warning for potentially invalid transitions
-                    warnings.warn(
-                        f"Potentially invalid transition from '{current_status}' to '{status}' "
-                        f"for {verbose_name} {self}",
-                        LiveStreamTransitionWarning,
-                    )
-
-        # Use provided service or get from season
-        service = youtube_service or self._live_stream_season().youtube
-
-        # Make the API call to transition the broadcast
-        response = (
-            service.liveBroadcasts()
-            .transition(
-                broadcastStatus=status,
-                id=self.external_identifier,
-                part="snippet,status",
-            )
-            .execute()
-        )
-
-        return response
-
-
-class Match(LiveStreamTransitionMixin, AdminUrlMixin, models.Model):
+class Match(AdminUrlMixin, models.Model):
     uuid = models.UUIDField(
         primary_key=False,
         default=uuid.uuid4,
@@ -2535,8 +2444,80 @@ class Match(LiveStreamTransitionMixin, AdminUrlMixin, models.Model):
             res[index] = team
         return tuple(res)
 
-    def _live_stream_season(self):
-        return self.stage.division.season
+    def transition_live_stream(self, status, youtube_service=None):
+        """
+        Transition the live stream status of this match.
+
+        Args:
+            status (str): The target broadcast status ('testing', 'live', 'complete')
+            youtube_service: Optional YouTube API service instance. If None, will use
+                           season's YouTube service.
+
+        Returns:
+            dict: Response from YouTube API
+
+        Raises:
+            LiveStreamIdentifierMissing: If the match has no external_identifier
+            InvalidLiveStreamTransition: If the transition is invalid
+            LiveStreamTransitionWarning: Warning for potentially invalid transitions
+        """
+        # Check if match has live stream identifier
+        if not self.external_identifier:
+            raise LiveStreamIdentifierMissing(
+                f"Match {self} does not have a live stream identifier"
+            )
+
+        # Define valid transitions
+        valid_transitions = {"testing": ["live"], "live": ["complete"], "complete": []}
+
+        # Get current broadcast status from YouTube if available
+        current_status = None
+        if youtube_service:
+            try:
+                response = (
+                    youtube_service.liveBroadcasts()
+                    .list(part="status", id=self.external_identifier)
+                    .execute()
+                )
+                if response.get("items"):
+                    current_status = response["items"][0]["status"]["lifeCycleStatus"]
+            except Exception:
+                # If we can't get current status, proceed anyway
+                pass
+
+        # Check for invalid transitions based on known current status
+        if current_status:
+            valid_next_states = valid_transitions.get(current_status, [])
+            if status not in valid_next_states and status != current_status:
+                if current_status == "complete":
+                    # Can't transition from complete to anything
+                    raise InvalidLiveStreamTransition(
+                        f"Cannot transition from '{current_status}' to '{status}' "
+                        f"for match {self}"
+                    )
+                else:
+                    # Issue warning for potentially invalid transitions
+                    warnings.warn(
+                        f"Potentially invalid transition from '{current_status}' to '{status}' "
+                        f"for match {self}",
+                        LiveStreamTransitionWarning,
+                    )
+
+        # Use provided service or get from season
+        service = youtube_service or self.stage.division.season.youtube
+
+        # Make the API call to transition the broadcast
+        response = (
+            service.liveBroadcasts()
+            .transition(
+                broadcastStatus=status,
+                id=self.external_identifier,
+                part="snippet,status",
+            )
+            .execute()
+        )
+
+        return response
 
     def __str__(self):
         return self.title
@@ -2772,10 +2753,11 @@ class SeasonMatchTime(AdminUrlMixin, MatchTimeBase):
         return "#{}".format(self.pk)
 
 
-class LiveStreamEvent(LiveStreamTransitionMixin, AdminUrlMixin, models.Model):
+class LiveStreamEvent(AdminUrlMixin, models.Model):
     """
     An adhoc live stream event associated with a Season.
 
+    This is a standalone feature — it has no crossover with match streaming.
     Unlike a Match, which derives its broadcast window from the fixture, an
     adhoc event captures an explicit scheduled start and stop time — for
     example an opening ceremony, an awards presentation, or a commentary
@@ -2804,19 +2786,6 @@ class LiveStreamEvent(LiveStreamTransitionMixin, AdminUrlMixin, models.Model):
         help_text=_("When the live stream is scheduled to conclude."),
     )
 
-    ground = ForeignKey(
-        Ground,
-        blank=True,
-        null=True,
-        related_name="live_stream_events",
-        label_from_instance="title",
-        on_delete=SET_NULL,
-        help_text=_(
-            "The stream (camera) that will broadcast this event — the "
-            "broadcast will be bound to this ground's stream key."
-        ),
-    )
-
     live_stream = BooleanField(
         default=True,
         help_text=_(
@@ -2824,11 +2793,17 @@ class LiveStreamEvent(LiveStreamTransitionMixin, AdminUrlMixin, models.Model):
             "platform while keeping this event for your records."
         ),
     )
+    stream_key = models.CharField(
+        max_length=50,
+        blank=True,
+        null=True,
+        help_text=_(
+            "The stream key the camera or encoder operator should use to "
+            "deliver video for this event."
+        ),
+    )
     external_identifier = models.CharField(
         max_length=20, blank=True, null=True, unique=True, db_index=True
-    )
-    live_stream_bind = models.CharField(
-        max_length=50, blank=True, null=True, db_index=True
     )
     live_stream_thumbnail_image = models.BinaryField(
         blank=True,
@@ -2854,22 +2829,15 @@ class LiveStreamEvent(LiveStreamTransitionMixin, AdminUrlMixin, models.Model):
         # No per-object permissions view is routed for this model.
         return ["add", "edit", "delete"]
 
-    def _live_stream_season(self):
-        return self.season
-
     def clean(self):
-        errors = {}
         if self.start and self.stop and self.stop <= self.start:
-            errors.setdefault("stop", []).append(
-                _("The scheduled finish must be after the scheduled start.")
+            raise ValidationError(
+                {
+                    "stop": [
+                        _("The scheduled finish must be after the scheduled start.")
+                    ]
+                }
             )
-        if self.ground_id and self.season_id:
-            if self.ground.venue.season_id != self.season_id:
-                errors.setdefault("ground", []).append(
-                    _("This ground is not part of this season.")
-                )
-        if errors:
-            raise ValidationError(errors)
 
     def get_thumbnail_media_upload(self) -> MediaUpload | None:
         """

--- a/tournamentcontrol/competition/models.py
+++ b/tournamentcontrol/competition/models.py
@@ -48,6 +48,7 @@ from timezone_field.fields import TimeZoneField
 from touchtechnology.admin.mixins import AdminUrlMixin as BaseAdminUrlMixin
 from touchtechnology.common.db.models import (
     BooleanField,
+    DateTimeField as SelectDateTimeField,
     ForeignKey,
     HTMLField,
     LocationField,
@@ -543,6 +544,16 @@ class Season(AdminUrlMixin, OrderedSitemapNode):
 
     def _get_url_args(self):
         return (self.competition_id, self.pk)
+
+    @cached_property
+    def _mvp_related(self):
+        return {
+            # live-stream thumbnail blobs are only needed by the thumbnail
+            # views, never drag them out of the database for list views.
+            "live_stream_events": self.live_stream_events.select_related(
+                "ground"
+            ).defer("live_stream_thumbnail_image"),
+        }
 
     def __repr__(self):
         return "<Season: {} - {}>".format(self.competition, self)
@@ -1953,7 +1964,98 @@ class SeasonAssociation(AdminUrlMixin, models.Model):
         ]
 
 
-class Match(AdminUrlMixin, models.Model):
+class LiveStreamTransitionMixin:
+    """
+    Shared YouTube ``liveBroadcasts.transition`` behaviour for models that
+    represent a broadcast (``Match`` and ``LiveStreamEvent``).
+
+    Concrete models must provide an ``external_identifier`` field holding the
+    YouTube broadcast identifier, and a ``_live_stream_season`` method
+    returning the ``Season`` whose OAuth2 credentials operate the channel.
+    """
+
+    def _live_stream_season(self):
+        raise NotImplementedError
+
+    def transition_live_stream(self, status, youtube_service=None):
+        """
+        Transition the live stream status of this broadcast.
+
+        Args:
+            status (str): The target broadcast status ('testing', 'live', 'complete')
+            youtube_service: Optional YouTube API service instance. If None, will use
+                           season's YouTube service.
+
+        Returns:
+            dict: Response from YouTube API
+
+        Raises:
+            LiveStreamIdentifierMissing: If there is no external_identifier
+            InvalidLiveStreamTransition: If the transition is invalid
+            LiveStreamTransitionWarning: Warning for potentially invalid transitions
+        """
+        verbose_name = self._meta.verbose_name
+
+        # Check for a live stream identifier
+        if not self.external_identifier:
+            raise LiveStreamIdentifierMissing(
+                f"{verbose_name.capitalize()} {self} does not have a live stream identifier"
+            )
+
+        # Define valid transitions
+        valid_transitions = {"testing": ["live"], "live": ["complete"], "complete": []}
+
+        # Get current broadcast status from YouTube if available
+        current_status = None
+        if youtube_service:
+            try:
+                response = (
+                    youtube_service.liveBroadcasts()
+                    .list(part="status", id=self.external_identifier)
+                    .execute()
+                )
+                if response.get("items"):
+                    current_status = response["items"][0]["status"]["lifeCycleStatus"]
+            except Exception:
+                # If we can't get current status, proceed anyway
+                pass
+
+        # Check for invalid transitions based on known current status
+        if current_status:
+            valid_next_states = valid_transitions.get(current_status, [])
+            if status not in valid_next_states and status != current_status:
+                if current_status == "complete":
+                    # Can't transition from complete to anything
+                    raise InvalidLiveStreamTransition(
+                        f"Cannot transition from '{current_status}' to '{status}' "
+                        f"for {verbose_name} {self}"
+                    )
+                else:
+                    # Issue warning for potentially invalid transitions
+                    warnings.warn(
+                        f"Potentially invalid transition from '{current_status}' to '{status}' "
+                        f"for {verbose_name} {self}",
+                        LiveStreamTransitionWarning,
+                    )
+
+        # Use provided service or get from season
+        service = youtube_service or self._live_stream_season().youtube
+
+        # Make the API call to transition the broadcast
+        response = (
+            service.liveBroadcasts()
+            .transition(
+                broadcastStatus=status,
+                id=self.external_identifier,
+                part="snippet,status",
+            )
+            .execute()
+        )
+
+        return response
+
+
+class Match(LiveStreamTransitionMixin, AdminUrlMixin, models.Model):
     uuid = models.UUIDField(
         primary_key=False,
         default=uuid.uuid4,
@@ -2433,80 +2535,8 @@ class Match(AdminUrlMixin, models.Model):
             res[index] = team
         return tuple(res)
 
-    def transition_live_stream(self, status, youtube_service=None):
-        """
-        Transition the live stream status of this match.
-
-        Args:
-            status (str): The target broadcast status ('testing', 'live', 'complete')
-            youtube_service: Optional YouTube API service instance. If None, will use
-                           season's YouTube service.
-
-        Returns:
-            dict: Response from YouTube API
-
-        Raises:
-            LiveStreamIdentifierMissing: If the match has no external_identifier
-            InvalidLiveStreamTransition: If the transition is invalid
-            LiveStreamTransitionWarning: Warning for potentially invalid transitions
-        """
-        # Check if match has live stream identifier
-        if not self.external_identifier:
-            raise LiveStreamIdentifierMissing(
-                f"Match {self} does not have a live stream identifier"
-            )
-
-        # Define valid transitions
-        valid_transitions = {"testing": ["live"], "live": ["complete"], "complete": []}
-
-        # Get current broadcast status from YouTube if available
-        current_status = None
-        if youtube_service:
-            try:
-                response = (
-                    youtube_service.liveBroadcasts()
-                    .list(part="status", id=self.external_identifier)
-                    .execute()
-                )
-                if response.get("items"):
-                    current_status = response["items"][0]["status"]["lifeCycleStatus"]
-            except Exception:
-                # If we can't get current status, proceed anyway
-                pass
-
-        # Check for invalid transitions based on known current status
-        if current_status:
-            valid_next_states = valid_transitions.get(current_status, [])
-            if status not in valid_next_states and status != current_status:
-                if current_status == "complete":
-                    # Can't transition from complete to anything
-                    raise InvalidLiveStreamTransition(
-                        f"Cannot transition from '{current_status}' to '{status}' "
-                        f"for match {self}"
-                    )
-                else:
-                    # Issue warning for potentially invalid transitions
-                    warnings.warn(
-                        f"Potentially invalid transition from '{current_status}' to '{status}' "
-                        f"for match {self}",
-                        LiveStreamTransitionWarning,
-                    )
-
-        # Use provided service or get from season
-        service = youtube_service or self.stage.division.season.youtube
-
-        # Make the API call to transition the broadcast
-        response = (
-            service.liveBroadcasts()
-            .transition(
-                broadcastStatus=status,
-                id=self.external_identifier,
-                part="snippet,status",
-            )
-            .execute()
-        )
-
-        return response
+    def _live_stream_season(self):
+        return self.stage.division.season
 
     def __str__(self):
         return self.title
@@ -2740,6 +2770,146 @@ class SeasonMatchTime(AdminUrlMixin, MatchTimeBase):
 
     def __str__(self):
         return "#{}".format(self.pk)
+
+
+class LiveStreamEvent(LiveStreamTransitionMixin, AdminUrlMixin, models.Model):
+    """
+    An adhoc live stream event associated with a Season.
+
+    Unlike a Match, which derives its broadcast window from the fixture, an
+    adhoc event captures an explicit scheduled start and stop time — for
+    example an opening ceremony, an awards presentation, or a commentary
+    desk between fixtures.
+    """
+
+    season = ForeignKey(
+        Season, related_name="live_stream_events", on_delete=CASCADE
+    )
+
+    title = models.CharField(
+        max_length=100,
+        help_text=_("Title of the broadcast on the YouTube platform."),
+    )
+    description = models.TextField(
+        blank=True,
+        help_text=_("Description of the broadcast on the YouTube platform."),
+    )
+
+    start = SelectDateTimeField(
+        verbose_name=_("Scheduled start"),
+        help_text=_("When the live stream is scheduled to commence."),
+    )
+    stop = SelectDateTimeField(
+        verbose_name=_("Scheduled finish"),
+        help_text=_("When the live stream is scheduled to conclude."),
+    )
+
+    ground = ForeignKey(
+        Ground,
+        blank=True,
+        null=True,
+        related_name="live_stream_events",
+        label_from_instance="title",
+        on_delete=SET_NULL,
+        help_text=_(
+            "The stream (camera) that will broadcast this event — the "
+            "broadcast will be bound to this ground's stream key."
+        ),
+    )
+
+    live_stream = BooleanField(
+        default=True,
+        help_text=_(
+            "Set to No to remove the scheduled broadcast from the YouTube "
+            "platform while keeping this event for your records."
+        ),
+    )
+    external_identifier = models.CharField(
+        max_length=20, blank=True, null=True, unique=True, db_index=True
+    )
+    live_stream_bind = models.CharField(
+        max_length=50, blank=True, null=True, db_index=True
+    )
+    live_stream_thumbnail_image = models.BinaryField(
+        blank=True,
+        null=True,
+        editable=True,
+        help_text="Image to be used as thumbnail image on the YouTube platform",
+    )
+
+    class Meta:
+        ordering = ("start", "title")
+        verbose_name = "live stream event"
+
+    def __str__(self):
+        return self.title
+
+    def _get_admin_namespace(self):
+        return "admin:fixja:competition:season:livestreamevent"
+
+    def _get_url_args(self):
+        return (self.season.competition_id, self.season_id, self.pk)
+
+    def _get_url_names(self):
+        # No per-object permissions view is routed for this model.
+        return ["add", "edit", "delete"]
+
+    def _live_stream_season(self):
+        return self.season
+
+    def clean(self):
+        errors = {}
+        if self.start and self.stop and self.stop <= self.start:
+            errors.setdefault("stop", []).append(
+                _("The scheduled finish must be after the scheduled start.")
+            )
+        if self.ground_id and self.season_id:
+            if self.ground.venue.season_id != self.season_id:
+                errors.setdefault("ground", []).append(
+                    _("This ground is not part of this season.")
+                )
+        if errors:
+            raise ValidationError(errors)
+
+    def get_thumbnail_media_upload(self) -> MediaUpload | None:
+        """
+        Get a MediaMemoryUpload instance for this event's thumbnail.
+        Falls back to season thumbnail if the event has no specific thumbnail.
+
+        Returns:
+            MediaMemoryUpload or None if no thumbnail is available
+        """
+        if self.live_stream_thumbnail_image:
+            return MediaMemoryUpload(self.live_stream_thumbnail_image, resumable=True)
+
+        if self.season.live_stream_thumbnail_image:
+            return MediaMemoryUpload(
+                self.season.live_stream_thumbnail_image, resumable=True
+            )
+
+        return None
+
+    def live_stream_thumbnail_response(self, width=None, height=None) -> HttpResponse:
+        """
+        Get HttpResponse for this event's thumbnail image.
+        Falls back to season thumbnail if the event has no specific thumbnail.
+
+        Args:
+            width (int, optional): Maximum width for resizing
+            height (int, optional): Maximum height for resizing
+
+        Returns:
+            HttpResponse: Image response with appropriate headers
+
+        Raises:
+            Http404: If no thumbnail is available or processing fails
+        """
+        return create_thumbnail_response(
+            self.live_stream_thumbnail_image
+            or self.season.live_stream_thumbnail_image,
+            width,
+            height,
+        )
 
 
 class MatchScoreSheet(AdminUrlMixin, models.Model):

--- a/tournamentcontrol/competition/models.py
+++ b/tournamentcontrol/competition/models.py
@@ -2776,12 +2776,10 @@ class LiveStreamKey(AdminUrlMixin, models.Model):
             "production position that will use it."
         ),
     )
-    external_identifier = models.CharField(
-        max_length=50, blank=True, null=True, unique=True, db_index=True
-    )
-    stream_key = models.CharField(
-        max_length=50, blank=True, null=True, unique=True, db_index=True
-    )
+    # The liveStream identifier issued by the YouTube platform is globally
+    # unique and never reused, so it serves as the primary key.
+    external_identifier = models.CharField(max_length=50, primary_key=True)
+    stream_key = models.CharField(max_length=50, unique=True, db_index=True)
 
     class Meta:
         ordering = ("title", "pk")
@@ -2844,7 +2842,8 @@ class LiveStreamEvent(AdminUrlMixin, models.Model):
         default=True,
         help_text=_(
             "Set to No to remove the scheduled broadcast from the YouTube "
-            "platform while keeping this event for your records."
+            "platform while keeping this event for your records. The "
+            "broadcast cannot be reinstated once removed."
         ),
     )
     stream_key = ForeignKey(
@@ -2859,9 +2858,11 @@ class LiveStreamEvent(AdminUrlMixin, models.Model):
             "deliver video for this event."
         ),
     )
-    external_identifier = models.CharField(
-        max_length=20, blank=True, null=True, unique=True, db_index=True
-    )
+    # The broadcast identifier issued by the YouTube platform is globally
+    # unique and never reused, so it serves as the primary key. The
+    # broadcast is created when the event is, and the record retains its
+    # identifier even after the broadcast is removed from the platform.
+    external_identifier = models.CharField(max_length=20, primary_key=True)
     live_stream_bind = models.CharField(
         max_length=50, blank=True, null=True, db_index=True
     )

--- a/tournamentcontrol/competition/models.py
+++ b/tournamentcontrol/competition/models.py
@@ -550,9 +550,9 @@ class Season(AdminUrlMixin, OrderedSitemapNode):
         return {
             # live-stream thumbnail blobs are only needed by the thumbnail
             # views, never drag them out of the database for list views.
-            "live_stream_events": self.live_stream_events.defer(
-                "live_stream_thumbnail_image"
-            ),
+            "live_stream_events": self.live_stream_events.select_related(
+                "stream_key"
+            ).defer("live_stream_thumbnail_image"),
         }
 
     def __repr__(self):
@@ -2753,6 +2753,60 @@ class SeasonMatchTime(AdminUrlMixin, MatchTimeBase):
         return "#{}".format(self.pk)
 
 
+class LiveStreamKey(AdminUrlMixin, models.Model):
+    """
+    A managed stream key associated with a Season, for use by adhoc live
+    stream events.
+
+    Each record is backed by a liveStream resource on the YouTube platform —
+    the generated stream key is what the camera or encoder operator uses to
+    deliver video. This pool is a unique domain associated to the season and
+    is entirely separate from the stream keys managed against grounds for
+    match streaming.
+    """
+
+    season = ForeignKey(
+        Season, related_name="live_stream_keys", on_delete=CASCADE
+    )
+
+    title = models.CharField(
+        max_length=100,
+        help_text=_(
+            "Identify this stream key — for example the camera or "
+            "production position that will use it."
+        ),
+    )
+    external_identifier = models.CharField(
+        max_length=50, blank=True, null=True, unique=True, db_index=True
+    )
+    stream_key = models.CharField(
+        max_length=50, blank=True, null=True, unique=True, db_index=True
+    )
+
+    class Meta:
+        ordering = ("title", "pk")
+        verbose_name = "stream key"
+
+    def __str__(self):
+        return self.label
+
+    @property
+    def label(self):
+        if self.stream_key:
+            return f"{self.title} ({self.stream_key})"
+        return self.title
+
+    def _get_admin_namespace(self):
+        return "admin:fixja:competition:season:livestreamkey"
+
+    def _get_url_args(self):
+        return (self.season.competition_id, self.season_id, self.pk)
+
+    def _get_url_names(self):
+        # No per-object permissions view is routed for this model.
+        return ["add", "edit", "delete"]
+
+
 class LiveStreamEvent(AdminUrlMixin, models.Model):
     """
     An adhoc live stream event associated with a Season.
@@ -2793,10 +2847,13 @@ class LiveStreamEvent(AdminUrlMixin, models.Model):
             "platform while keeping this event for your records."
         ),
     )
-    stream_key = models.CharField(
-        max_length=50,
+    stream_key = ForeignKey(
+        LiveStreamKey,
         blank=True,
         null=True,
+        related_name="live_stream_events",
+        label_from_instance="label",
+        on_delete=PROTECT,
         help_text=_(
             "The stream key the camera or encoder operator should use to "
             "deliver video for this event."
@@ -2804,6 +2861,9 @@ class LiveStreamEvent(AdminUrlMixin, models.Model):
     )
     external_identifier = models.CharField(
         max_length=20, blank=True, null=True, unique=True, db_index=True
+    )
+    live_stream_bind = models.CharField(
+        max_length=50, blank=True, null=True, db_index=True
     )
     live_stream_thumbnail_image = models.BinaryField(
         blank=True,
@@ -2830,14 +2890,18 @@ class LiveStreamEvent(AdminUrlMixin, models.Model):
         return ["add", "edit", "delete"]
 
     def clean(self):
+        errors = {}
         if self.start and self.stop and self.stop <= self.start:
-            raise ValidationError(
-                {
-                    "stop": [
-                        _("The scheduled finish must be after the scheduled start.")
-                    ]
-                }
+            errors.setdefault("stop", []).append(
+                _("The scheduled finish must be after the scheduled start.")
             )
+        if self.stream_key_id and self.season_id:
+            if self.stream_key.season_id != self.season_id:
+                errors.setdefault("stream_key", []).append(
+                    _("This stream key does not belong to this season.")
+                )
+        if errors:
+            raise ValidationError(errors)
 
     def get_thumbnail_media_upload(self) -> MediaUpload | None:
         """

--- a/tournamentcontrol/competition/signals/live_streams.py
+++ b/tournamentcontrol/competition/signals/live_streams.py
@@ -1,0 +1,48 @@
+import logging
+
+from django.db import transaction
+
+from tournamentcontrol.competition.tasks import (
+    delete_youtube_broadcast,
+    delete_youtube_stream,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _season_credentials(instance):
+    """Return the instance's season when its YouTube credentials are set."""
+    season = instance.season
+    if season.live_stream_client_id and season.live_stream_client_secret:
+        return season
+    return None
+
+
+def cleanup_youtube_broadcast(sender, instance, **kwargs):
+    """
+    When a LiveStreamEvent is deleted, remove its scheduled broadcast from
+    the YouTube platform too.
+    """
+    season = _season_credentials(instance)
+    if season is None or not instance.external_identifier:
+        return
+    external_identifier = instance.external_identifier
+    transaction.on_commit(
+        lambda: delete_youtube_broadcast.s(
+            season.pk, external_identifier
+        ).apply_async()
+    )
+
+
+def cleanup_youtube_stream(sender, instance, **kwargs):
+    """
+    When a LiveStreamKey is deleted, remove its liveStream resource from
+    the YouTube platform too.
+    """
+    season = _season_credentials(instance)
+    if season is None or not instance.external_identifier:
+        return
+    external_identifier = instance.external_identifier
+    transaction.on_commit(
+        lambda: delete_youtube_stream.s(season.pk, external_identifier).apply_async()
+    )

--- a/tournamentcontrol/competition/tasks.py
+++ b/tournamentcontrol/competition/tasks.py
@@ -324,14 +324,15 @@ def build_live_stream_event_body(event):
 
 
 def _apply_event_sync(event, season):
-    """Apply a single insert/update/delete cycle against YouTube."""
+    """Apply a single insert/update/delete + bind cycle against YouTube."""
     youtube = season.youtube
 
     if event.external_identifier and not event.live_stream:
         video_id = event.external_identifier
         youtube.liveBroadcasts().delete(id=video_id).execute()
         event.external_identifier = None
-        event.save(update_fields=["external_identifier"])
+        event.live_stream_bind = None
+        event.save(update_fields=["external_identifier", "live_stream_bind"])
         logger.info("YouTube video %r deleted", video_id)
         return
 
@@ -355,19 +356,43 @@ def _apply_event_sync(event, season):
     if event.get_thumbnail_media_upload() is not None:
         set_live_stream_event_thumbnail.s(event.pk).apply_async(countdown=10)
 
+    stream_key = event.stream_key
+    if stream_key is not None and stream_key.external_identifier:
+        bind = (
+            youtube.liveBroadcasts()
+            .bind(
+                part="id,snippet,contentDetails,status",
+                id=event.external_identifier,
+                streamId=stream_key.external_identifier,
+            )
+            .execute()
+        )
+        bound = bind["contentDetails"].get("boundStreamId")
+        if bound != event.live_stream_bind:
+            event.live_stream_bind = bound
+            event.save(update_fields=["live_stream_bind"])
+    elif event.live_stream_bind:
+        # The stream key has been unset since the broadcast was bound;
+        # calling bind without a streamId removes the existing binding.
+        youtube.liveBroadcasts().bind(
+            part="id,snippet,contentDetails,status",
+            id=event.external_identifier,
+        ).execute()
+        event.live_stream_bind = None
+        event.save(update_fields=["live_stream_bind"])
+
 
 @shared_task
 def sync_live_stream_event(event_pk):
     """Synchronize an adhoc live stream event with its YouTube broadcast.
 
-    Deliberately low touch: creates, updates, or deletes the scheduled
-    broadcast (and pushes the thumbnail) as required by the current state of
-    the event. Stream keys are managed by the operator on the event record;
-    connecting an encoder to the broadcast is done on the YouTube platform.
+    Creates, updates, or deletes the scheduled broadcast, pushes the
+    thumbnail, and binds the broadcast to the selected stream key from the
+    season's managed pool, as required by the current state of the event.
     """
     try:
         event = LiveStreamEvent.objects.select_related(
-            "season__competition"
+            "season__competition", "stream_key"
         ).get(pk=event_pk)
     except LiveStreamEvent.DoesNotExist:
         # Event was deleted between enqueuing and execution; nothing to sync.
@@ -436,6 +461,34 @@ def delete_youtube_broadcast(season_pk, external_identifier):
     except HttpError as exc:
         logger.error(
             "YouTube API error deleting broadcast %r: %s", external_identifier, exc
+        )
+        raise
+
+
+@shared_task
+def delete_youtube_stream(season_pk, external_identifier):
+    """Delete a YouTube liveStream that no longer has a local record.
+
+    Used when a managed stream key is deleted from the database while its
+    liveStream resource still exists on the YouTube platform.
+    """
+    try:
+        season = Season.objects.get(pk=season_pk)
+    except Season.DoesNotExist:
+        logger.info(
+            "delete_youtube_stream skipped: season %s no longer exists", season_pk
+        )
+        return
+
+    if not (season.live_stream_client_id and season.live_stream_client_secret):
+        return
+
+    try:
+        season.youtube.liveStreams().delete(id=external_identifier).execute()
+        logger.info("YouTube stream %r deleted", external_identifier)
+    except HttpError as exc:
+        logger.error(
+            "YouTube API error deleting stream %r: %s", external_identifier, exc
         )
         raise
 

--- a/tournamentcontrol/competition/tasks.py
+++ b/tournamentcontrol/competition/tasks.py
@@ -473,6 +473,11 @@ def delete_youtube_broadcast(season_pk, external_identifier):
         season.youtube.liveBroadcasts().delete(id=external_identifier).execute()
         logger.info("YouTube video %r deleted", external_identifier)
     except HttpError as exc:
+        # The admin delete view destroys the broadcast before removing the
+        # record, so this cleanup will usually find it already gone.
+        if _is_not_found(exc):
+            logger.info("YouTube video %r already deleted", external_identifier)
+            return
         logger.error(
             "YouTube API error deleting broadcast %r: %s", external_identifier, exc
         )
@@ -501,6 +506,11 @@ def delete_youtube_stream(season_pk, external_identifier):
         season.youtube.liveStreams().delete(id=external_identifier).execute()
         logger.info("YouTube stream %r deleted", external_identifier)
     except HttpError as exc:
+        # The admin delete view destroys the stream before removing the
+        # record, so this cleanup will usually find it already gone.
+        if _is_not_found(exc):
+            logger.info("YouTube stream %r already deleted", external_identifier)
+            return
         logger.error(
             "YouTube API error deleting stream %r: %s", external_identifier, exc
         )

--- a/tournamentcontrol/competition/tasks.py
+++ b/tournamentcontrol/competition/tasks.py
@@ -9,7 +9,12 @@ from django.template.loader import render_to_string
 from django.urls import NoReverseMatch, reverse
 from googleapiclient.errors import HttpError
 
-from tournamentcontrol.competition.models import Match, Stage
+from tournamentcontrol.competition.models import (
+    LiveStreamEvent,
+    Match,
+    Season,
+    Stage,
+)
 from tournamentcontrol.competition.utils import (
     generate_fixture_grid,
     generate_scorecards,
@@ -288,6 +293,175 @@ def sync_live_stream(match_pk, base_url=None):
                 continue
             logger.error("YouTube API error syncing match %s: %s", match_pk, exc)
             raise
+
+
+def build_live_stream_event_body(event):
+    """Build the YouTube broadcast body for an adhoc live stream event.
+
+    Unlike matches, adhoc events carry their own author-supplied title and
+    description, and an explicit scheduled start and stop time.
+    """
+    return {
+        "snippet": {
+            "title": event.title,
+            "description": event.description,
+            "scheduledStartTime": event.start.astimezone(ZoneInfo("UTC")).isoformat(),
+            "scheduledEndTime": event.stop.astimezone(ZoneInfo("UTC")).isoformat(),
+        },
+        "status": {
+            "privacyStatus": event.season.live_stream_privacy,
+            "selfDeclaredMadeForKids": False,
+        },
+        "contentDetails": {
+            "enableAutoStart": False,
+            "enableAutoStop": False,
+            "monitorStream": {
+                "broadcastStreamDelayMs": 0,
+                "enableMonitorStream": True,
+            },
+        },
+    }
+
+
+def _apply_event_sync(event, season):
+    """Apply a single insert/update/delete + bind cycle against YouTube."""
+    youtube = season.youtube
+
+    if event.external_identifier and not event.live_stream:
+        video_id = event.external_identifier
+        youtube.liveBroadcasts().delete(id=video_id).execute()
+        event.external_identifier = None
+        event.live_stream_bind = None
+        event.save(update_fields=["external_identifier", "live_stream_bind"])
+        logger.info("YouTube video %r deleted", video_id)
+        return
+
+    body = build_live_stream_event_body(event)
+    if event.external_identifier:
+        body["id"] = event.external_identifier
+        youtube.liveBroadcasts().update(
+            part="snippet,status,contentDetails", body=body
+        ).execute()
+        logger.info("YouTube video %r updated", event.external_identifier)
+    else:
+        broadcast = (
+            youtube.liveBroadcasts()
+            .insert(part="id,snippet,status,contentDetails", body=body)
+            .execute()
+        )
+        event.external_identifier = broadcast["id"]
+        event.save(update_fields=["external_identifier"])
+        logger.info("YouTube video %r inserted", event.external_identifier)
+
+    if event.get_thumbnail_media_upload() is not None:
+        set_live_stream_event_thumbnail.s(event.pk).apply_async(countdown=10)
+
+    ground = event.ground
+    if ground is not None and ground.external_identifier:
+        bind = (
+            youtube.liveBroadcasts()
+            .bind(
+                part="id,snippet,contentDetails,status",
+                id=event.external_identifier,
+                streamId=ground.external_identifier,
+            )
+            .execute()
+        )
+        bound = bind["contentDetails"].get("boundStreamId")
+        if bound != event.live_stream_bind:
+            event.live_stream_bind = bound
+            event.save(update_fields=["live_stream_bind"])
+    elif event.live_stream_bind:
+        # The stream has been unset since the broadcast was bound; calling
+        # bind without a streamId removes the existing binding.
+        youtube.liveBroadcasts().bind(
+            part="id,snippet,contentDetails,status",
+            id=event.external_identifier,
+        ).execute()
+        event.live_stream_bind = None
+        event.save(update_fields=["live_stream_bind"])
+
+
+@shared_task
+def sync_live_stream_event(event_pk):
+    """Synchronize an adhoc live stream event with its YouTube broadcast.
+
+    Creates, updates, deletes, and binds the live broadcast as required by
+    the current state of the event.
+    """
+    try:
+        event = LiveStreamEvent.objects.select_related(
+            "season__competition", "ground"
+        ).get(pk=event_pk)
+    except LiveStreamEvent.DoesNotExist:
+        # Event was deleted between enqueuing and execution; nothing to sync.
+        logger.info(
+            "sync_live_stream_event skipped: event %s no longer exists", event_pk
+        )
+        return
+    season = event.season
+
+    if not (season.live_stream_client_id and season.live_stream_client_secret):
+        return
+
+    if not event.live_stream and not event.external_identifier:
+        return  # Nothing to insert, update, or delete.
+
+    try:
+        _apply_event_sync(event, season)
+    except HttpError as exc:
+        logger.error("YouTube API error syncing event %s: %s", event_pk, exc)
+        raise
+
+
+@shared_task
+def set_live_stream_event_thumbnail(event_pk):
+    """
+    Asynchronously use the Google YouTube Data API to set the thumbnail for
+    the adhoc live stream event specified.
+
+    This function uses the database-stored thumbnail images via the
+    MediaMemoryUpload class, with season fallback handled by the model.
+    """
+    obj = LiveStreamEvent.objects.get(pk=event_pk)
+
+    media_body = obj.get_thumbnail_media_upload()
+
+    if media_body is None:
+        raise ValueError(f"No thumbnail available for live stream event {event_pk}")
+
+    obj.season.youtube.thumbnails().set(
+        videoId=obj.external_identifier,
+        media_body=media_body,
+    ).execute()
+
+
+@shared_task
+def delete_youtube_broadcast(season_pk, external_identifier):
+    """Delete a YouTube broadcast that no longer has a local record.
+
+    Used when an adhoc live stream event is deleted from the database while
+    its broadcast is still scheduled on the YouTube platform.
+    """
+    try:
+        season = Season.objects.get(pk=season_pk)
+    except Season.DoesNotExist:
+        logger.info(
+            "delete_youtube_broadcast skipped: season %s no longer exists", season_pk
+        )
+        return
+
+    if not (season.live_stream_client_id and season.live_stream_client_secret):
+        return
+
+    try:
+        season.youtube.liveBroadcasts().delete(id=external_identifier).execute()
+        logger.info("YouTube video %r deleted", external_identifier)
+    except HttpError as exc:
+        logger.error(
+            "YouTube API error deleting broadcast %r: %s", external_identifier, exc
+        )
+        raise
 
 
 @shared_task

--- a/tournamentcontrol/competition/tasks.py
+++ b/tournamentcontrol/competition/tasks.py
@@ -324,15 +324,14 @@ def build_live_stream_event_body(event):
 
 
 def _apply_event_sync(event, season):
-    """Apply a single insert/update/delete + bind cycle against YouTube."""
+    """Apply a single insert/update/delete cycle against YouTube."""
     youtube = season.youtube
 
     if event.external_identifier and not event.live_stream:
         video_id = event.external_identifier
         youtube.liveBroadcasts().delete(id=video_id).execute()
         event.external_identifier = None
-        event.live_stream_bind = None
-        event.save(update_fields=["external_identifier", "live_stream_bind"])
+        event.save(update_fields=["external_identifier"])
         logger.info("YouTube video %r deleted", video_id)
         return
 
@@ -356,42 +355,19 @@ def _apply_event_sync(event, season):
     if event.get_thumbnail_media_upload() is not None:
         set_live_stream_event_thumbnail.s(event.pk).apply_async(countdown=10)
 
-    ground = event.ground
-    if ground is not None and ground.external_identifier:
-        bind = (
-            youtube.liveBroadcasts()
-            .bind(
-                part="id,snippet,contentDetails,status",
-                id=event.external_identifier,
-                streamId=ground.external_identifier,
-            )
-            .execute()
-        )
-        bound = bind["contentDetails"].get("boundStreamId")
-        if bound != event.live_stream_bind:
-            event.live_stream_bind = bound
-            event.save(update_fields=["live_stream_bind"])
-    elif event.live_stream_bind:
-        # The stream has been unset since the broadcast was bound; calling
-        # bind without a streamId removes the existing binding.
-        youtube.liveBroadcasts().bind(
-            part="id,snippet,contentDetails,status",
-            id=event.external_identifier,
-        ).execute()
-        event.live_stream_bind = None
-        event.save(update_fields=["live_stream_bind"])
-
 
 @shared_task
 def sync_live_stream_event(event_pk):
     """Synchronize an adhoc live stream event with its YouTube broadcast.
 
-    Creates, updates, deletes, and binds the live broadcast as required by
-    the current state of the event.
+    Deliberately low touch: creates, updates, or deletes the scheduled
+    broadcast (and pushes the thumbnail) as required by the current state of
+    the event. Stream keys are managed by the operator on the event record;
+    connecting an encoder to the broadcast is done on the YouTube platform.
     """
     try:
         event = LiveStreamEvent.objects.select_related(
-            "season__competition", "ground"
+            "season__competition"
         ).get(pk=event_pk)
     except LiveStreamEvent.DoesNotExist:
         # Event was deleted between enqueuing and execution; nothing to sync.

--- a/tournamentcontrol/competition/tasks.py
+++ b/tournamentcontrol/competition/tasks.py
@@ -323,41 +323,58 @@ def build_live_stream_event_body(event):
     }
 
 
+def _is_not_found(exc):
+    """Return True when an HttpError indicates the resource no longer exists."""
+    return getattr(getattr(exc, "resp", None), "status", None) == 404
+
+
 def _apply_event_sync(event, season):
-    """Apply a single insert/update/delete + bind cycle against YouTube."""
+    """Apply a single update/delete + bind cycle against YouTube.
+
+    The broadcast identifier is the event's primary key — the broadcast is
+    created with the event, so there is no insert path here. A broadcast
+    which has already been removed from the platform (404) is tolerated.
+    """
     youtube = season.youtube
 
-    if event.external_identifier and not event.live_stream:
-        video_id = event.external_identifier
-        youtube.liveBroadcasts().delete(id=video_id).execute()
-        event.external_identifier = None
-        event.live_stream_bind = None
-        event.save(update_fields=["external_identifier", "live_stream_bind"])
-        logger.info("YouTube video %r deleted", video_id)
+    if not event.live_stream:
+        try:
+            youtube.liveBroadcasts().delete(id=event.external_identifier).execute()
+            logger.info("YouTube video %r deleted", event.external_identifier)
+        except HttpError as exc:
+            if not _is_not_found(exc):
+                raise
+            logger.info(
+                "YouTube video %r already deleted", event.external_identifier
+            )
+        if event.live_stream_bind:
+            event.live_stream_bind = None
+            event.save(update_fields=["live_stream_bind"])
         return
 
     body = build_live_stream_event_body(event)
-    if event.external_identifier:
-        body["id"] = event.external_identifier
+    body["id"] = event.external_identifier
+    try:
         youtube.liveBroadcasts().update(
             part="snippet,status,contentDetails", body=body
         ).execute()
         logger.info("YouTube video %r updated", event.external_identifier)
-    else:
-        broadcast = (
-            youtube.liveBroadcasts()
-            .insert(part="id,snippet,status,contentDetails", body=body)
-            .execute()
+    except HttpError as exc:
+        if not _is_not_found(exc):
+            raise
+        # The broadcast was previously removed from the platform and cannot
+        # be reinstated under the same identifier.
+        logger.warning(
+            "YouTube video %r no longer exists, skipping sync",
+            event.external_identifier,
         )
-        event.external_identifier = broadcast["id"]
-        event.save(update_fields=["external_identifier"])
-        logger.info("YouTube video %r inserted", event.external_identifier)
+        return
 
     if event.get_thumbnail_media_upload() is not None:
         set_live_stream_event_thumbnail.s(event.pk).apply_async(countdown=10)
 
     stream_key = event.stream_key
-    if stream_key is not None and stream_key.external_identifier:
+    if stream_key is not None:
         bind = (
             youtube.liveBroadcasts()
             .bind(
@@ -386,9 +403,9 @@ def _apply_event_sync(event, season):
 def sync_live_stream_event(event_pk):
     """Synchronize an adhoc live stream event with its YouTube broadcast.
 
-    Creates, updates, or deletes the scheduled broadcast, pushes the
-    thumbnail, and binds the broadcast to the selected stream key from the
-    season's managed pool, as required by the current state of the event.
+    Updates or deletes the scheduled broadcast, pushes the thumbnail, and
+    binds the broadcast to the selected stream key from the season's managed
+    pool, as required by the current state of the event.
     """
     try:
         event = LiveStreamEvent.objects.select_related(
@@ -404,9 +421,6 @@ def sync_live_stream_event(event_pk):
 
     if not (season.live_stream_client_id and season.live_stream_client_secret):
         return
-
-    if not event.live_stream and not event.external_identifier:
-        return  # Nothing to insert, update, or delete.
 
     try:
         _apply_event_sync(event, season)

--- a/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/livestreamevent/list.inc.html
+++ b/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/livestreamevent/list.inc.html
@@ -1,0 +1,31 @@
+{% extends "mvp/list.inc.html" %}
+{% load i18n %}
+
+{% block table-headings %}
+	<th>{% trans "Title" %}</th>
+	<th class="hidden-sm hidden-xs">{% trans "Start" %}</th>
+	<th class="hidden-sm hidden-xs">{% trans "Finish" %}</th>
+	<th>{% trans "Streaming" %}</th>
+{% endblock %}
+
+{% block table-columns %}
+	<td>
+		{% if change_perm in object_perms %}
+			<a href="{{ obj.urls.edit }}">{{ obj.title }}</a>&nbsp;
+		{% else %}
+			<span>{{ obj.title }}</span>
+		{% endif %}
+	</td>
+	<td class="hidden-sm hidden-xs">{{ obj.start }}</td>
+	<td class="hidden-sm hidden-xs">{{ obj.stop }}</td>
+	<td>
+		{% if obj.external_identifier %}
+			<em class="fa fa-youtube"></em>
+		{% endif %}
+		{% if obj.ground %}
+			{{ obj.ground.title }}{% if obj.ground.stream_key %} ({{ obj.ground.stream_key }}){% endif %}
+		{% endif %}
+	</td>
+{% endblock %}
+
+{% block empty-row-colspan %}5{% endblock %}

--- a/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/livestreamevent/list.inc.html
+++ b/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/livestreamevent/list.inc.html
@@ -22,8 +22,8 @@
 		{% if obj.external_identifier %}
 			<em class="fa fa-youtube"></em>
 		{% endif %}
-		{% if obj.ground %}
-			{{ obj.ground.title }}{% if obj.ground.stream_key %} ({{ obj.ground.stream_key }}){% endif %}
+		{% if obj.stream_key %}
+			{{ obj.stream_key }}
 		{% endif %}
 	</td>
 {% endblock %}

--- a/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/livestreamkey/list.inc.html
+++ b/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/livestreamkey/list.inc.html
@@ -3,9 +3,7 @@
 
 {% block table-headings %}
 	<th>{% trans "Title" %}</th>
-	<th class="hidden-sm hidden-xs">{% trans "Start" %}</th>
-	<th class="hidden-sm hidden-xs">{% trans "Finish" %}</th>
-	<th>{% trans "Streaming" %}</th>
+	<th>{% trans "Stream key" %}</th>
 {% endblock %}
 
 {% block table-columns %}
@@ -16,16 +14,14 @@
 			<span>{{ obj.title }}</span>
 		{% endif %}
 	</td>
-	<td class="hidden-sm hidden-xs">{{ obj.start }}</td>
-	<td class="hidden-sm hidden-xs">{{ obj.stop }}</td>
 	<td>
 		{% if obj.external_identifier %}
 			<em class="fa fa-youtube"></em>
 		{% endif %}
 		{% if obj.stream_key %}
-			{{ obj.stream_key.label }}
+			{{ obj.stream_key }}
 		{% endif %}
 	</td>
 {% endblock %}
 
-{% block empty-row-colspan %}5{% endblock %}
+{% block empty-row-colspan %}3{% endblock %}

--- a/tournamentcontrol/competition/tests/factories.py
+++ b/tournamentcontrol/competition/tests/factories.py
@@ -118,6 +118,9 @@ class LiveStreamKeyFactory(DjangoModelFactory):
     season = factory.SubFactory(SeasonFactory)
 
     title = factory.Sequence(lambda n: "Stream Key %d" % (n + 1))
+    # The YouTube liveStream identifier is the primary key.
+    external_identifier = factory.Sequence(lambda n: "stream%d" % (n + 1))
+    stream_key = factory.Sequence(lambda n: "abcd-%04d" % (n + 1))
 
 
 class LiveStreamEventFactory(DjangoModelFactory):
@@ -131,6 +134,8 @@ class LiveStreamEventFactory(DjangoModelFactory):
         datetime.datetime(2020, 1, 1, tzinfo=ZoneInfo("UTC"))
     )
     stop = factory.LazyAttribute(lambda o: o.start + datetime.timedelta(hours=1))
+    # The YouTube broadcast identifier is the primary key.
+    external_identifier = factory.Sequence(lambda n: "adhoc%d" % (n + 1))
 
 
 class DivisionFactory(OrderedSitemapNodeFactory):

--- a/tournamentcontrol/competition/tests/factories.py
+++ b/tournamentcontrol/competition/tests/factories.py
@@ -111,6 +111,19 @@ class GroundFactory(OrderedSitemapNodeFactory):
     venue = factory.SubFactory(VenueFactory)
 
 
+class LiveStreamEventFactory(DjangoModelFactory):
+    class Meta:
+        model = models.LiveStreamEvent
+
+    season = factory.SubFactory(SeasonFactory)
+
+    title = factory.Sequence(lambda n: "Live Stream Event %d" % (n + 1))
+    start = factory.fuzzy.FuzzyDateTime(
+        datetime.datetime(2020, 1, 1, tzinfo=ZoneInfo("UTC"))
+    )
+    stop = factory.LazyAttribute(lambda o: o.start + datetime.timedelta(hours=1))
+
+
 class DivisionFactory(OrderedSitemapNodeFactory):
     class Meta:
         model = models.Division

--- a/tournamentcontrol/competition/tests/factories.py
+++ b/tournamentcontrol/competition/tests/factories.py
@@ -111,6 +111,15 @@ class GroundFactory(OrderedSitemapNodeFactory):
     venue = factory.SubFactory(VenueFactory)
 
 
+class LiveStreamKeyFactory(DjangoModelFactory):
+    class Meta:
+        model = models.LiveStreamKey
+
+    season = factory.SubFactory(SeasonFactory)
+
+    title = factory.Sequence(lambda n: "Stream Key %d" % (n + 1))
+
+
 class LiveStreamEventFactory(DjangoModelFactory):
     class Meta:
         model = models.LiveStreamEvent

--- a/tournamentcontrol/competition/tests/test_competition_admin.py
+++ b/tournamentcontrol/competition/tests/test_competition_admin.py
@@ -339,6 +339,10 @@ class GoodViewTests(TestCase):
         matchtime = factories.SeasonMatchTimeFactory.create()
         self.assertGoodNamespace(matchtime)
 
+    def test_livestreamevent(self):
+        event = factories.LiveStreamEventFactory.create(season__live_stream=True)
+        self.assertGoodNamespace(event)
+
     def test_venue(self):
         venue = factories.VenueFactory.create()
         self.assertGoodNamespace(venue)

--- a/tournamentcontrol/competition/tests/test_competition_admin.py
+++ b/tournamentcontrol/competition/tests/test_competition_admin.py
@@ -343,6 +343,10 @@ class GoodViewTests(TestCase):
         event = factories.LiveStreamEventFactory.create(season__live_stream=True)
         self.assertGoodNamespace(event)
 
+    def test_livestreamkey(self):
+        stream_key = factories.LiveStreamKeyFactory.create(season__live_stream=True)
+        self.assertGoodNamespace(stream_key)
+
     def test_venue(self):
         venue = factories.VenueFactory.create()
         self.assertGoodNamespace(venue)

--- a/tournamentcontrol/competition/tests/test_live_stream_event.py
+++ b/tournamentcontrol/competition/tests/test_live_stream_event.py
@@ -41,19 +41,10 @@ class LiveStreamEventModelTests(TestCase):
             event.clean()
         self.assertIn("stop", cm.exception.message_dict)
 
-    def test_clean_rejects_ground_from_another_season(self):
-        event = factories.LiveStreamEventFactory.create()
-        other_ground = factories.GroundFactory.create()
-        event.ground = other_ground
-        with self.assertRaises(ValidationError) as cm:
-            event.clean()
-        self.assertIn("ground", cm.exception.message_dict)
-
-    def test_clean_accepts_ground_from_same_season(self):
-        event = factories.LiveStreamEventFactory.create()
-        ground = factories.GroundFactory.create(venue__season=event.season)
-        event.ground = ground
-        self.assertEqual(event.clean(), None)
+    def test_stream_key_round_trip(self):
+        event = factories.LiveStreamEventFactory.create(stream_key="abcd-1234")
+        event.refresh_from_db()
+        self.assertEqual(event.stream_key, "abcd-1234")
 
     def test_thumbnail_prefers_event_image(self):
         event = factories.LiveStreamEventFactory.create(
@@ -93,13 +84,6 @@ class LiveStreamEventModelTests(TestCase):
 
 
 class LiveStreamEventFormTests(TestCase):
-    def test_ground_queryset_limited_to_season(self):
-        event = factories.LiveStreamEventFactory.create()
-        ground = factories.GroundFactory.create(venue__season=event.season)
-        factories.GroundFactory.create()  # another season entirely
-        form = LiveStreamEventForm(instance=event)
-        self.assertCountEqual(form.fields["ground"].queryset, [ground])
-
     def test_stop_before_start_is_invalid(self):
         season = factories.SeasonFactory.create()
         form = LiveStreamEventForm(
@@ -132,6 +116,7 @@ class LiveStreamEventFormTests(TestCase):
                 "stop_0": "2025-05-01",
                 "stop_1": "20:30:00",
                 "stop_2": "UTC",
+                "stream_key": "abcd-1234",
                 "live_stream": "1",
             },
         )
@@ -144,6 +129,7 @@ class LiveStreamEventFormTests(TestCase):
         self.assertEqual(
             event.stop, datetime.datetime(2025, 5, 1, 20, 30, tzinfo=UTC)
         )
+        self.assertEqual(event.stream_key, "abcd-1234")
 
 
 class BuildLiveStreamEventBodyTests(TestCase):
@@ -212,39 +198,6 @@ class SyncLiveStreamEventTests(TestCase):
         "tournamentcontrol.competition.models.Season.youtube",
         new_callable=mock.PropertyMock,
     )
-    def test_insert_binds_to_ground_stream(self, mock_youtube_prop):
-        mock_youtube = mock.MagicMock()
-        mock_youtube_prop.return_value = mock_youtube
-        mock_youtube.liveBroadcasts.return_value.insert.return_value.execute.return_value = {
-            "id": "adhoc123"
-        }
-        mock_youtube.liveBroadcasts.return_value.bind.return_value.execute.return_value = {
-            "contentDetails": {"boundStreamId": "stream456"}
-        }
-
-        event = self._event()
-        event.ground = factories.GroundFactory.create(
-            venue__season=event.season,
-            live_stream=True,
-            external_identifier="stream456",
-            stream_key="abcd-1234",
-        )
-        event.save()
-
-        sync_live_stream_event(event.pk)
-
-        mock_youtube.liveBroadcasts.return_value.bind.assert_called_once_with(
-            part="id,snippet,contentDetails,status",
-            id="adhoc123",
-            streamId="stream456",
-        )
-        event.refresh_from_db()
-        self.assertEqual(event.live_stream_bind, "stream456")
-
-    @mock.patch(
-        "tournamentcontrol.competition.models.Season.youtube",
-        new_callable=mock.PropertyMock,
-    )
     def test_update_existing_broadcast(self, mock_youtube_prop):
         mock_youtube = mock.MagicMock()
         mock_youtube_prop.return_value = mock_youtube
@@ -270,7 +223,6 @@ class SyncLiveStreamEventTests(TestCase):
         event = self._event(
             external_identifier="adhoc123",
             live_stream=False,
-            live_stream_bind="stream456",
         )
         sync_live_stream_event(event.pk)
 
@@ -279,27 +231,6 @@ class SyncLiveStreamEventTests(TestCase):
         )
         event.refresh_from_db()
         self.assertEqual(event.external_identifier, None)
-        self.assertEqual(event.live_stream_bind, None)
-
-    @mock.patch(
-        "tournamentcontrol.competition.models.Season.youtube",
-        new_callable=mock.PropertyMock,
-    )
-    def test_unbinds_when_ground_removed(self, mock_youtube_prop):
-        mock_youtube = mock.MagicMock()
-        mock_youtube_prop.return_value = mock_youtube
-
-        event = self._event(
-            external_identifier="adhoc123", live_stream_bind="stream456"
-        )
-        sync_live_stream_event(event.pk)
-
-        mock_youtube.liveBroadcasts.return_value.bind.assert_called_once_with(
-            part="id,snippet,contentDetails,status",
-            id="adhoc123",
-        )
-        event.refresh_from_db()
-        self.assertEqual(event.live_stream_bind, None)
 
     @mock.patch(
         "tournamentcontrol.competition.models.Season.youtube",

--- a/tournamentcontrol/competition/tests/test_live_stream_event.py
+++ b/tournamentcontrol/competition/tests/test_live_stream_event.py
@@ -7,14 +7,16 @@ from unittest import mock
 from zoneinfo import ZoneInfo
 
 from django.core.exceptions import ValidationError
+from django.db.models import ProtectedError
 from test_plus import TestCase
 
 from touchtechnology.common.tests.factories import UserFactory
 from tournamentcontrol.competition.forms import LiveStreamEventForm
-from tournamentcontrol.competition.models import LiveStreamEvent
+from tournamentcontrol.competition.models import LiveStreamEvent, LiveStreamKey
 from tournamentcontrol.competition.tasks import (
     build_live_stream_event_body,
     delete_youtube_broadcast,
+    delete_youtube_stream,
     sync_live_stream_event,
 )
 from tournamentcontrol.competition.tests import factories
@@ -41,10 +43,18 @@ class LiveStreamEventModelTests(TestCase):
             event.clean()
         self.assertIn("stop", cm.exception.message_dict)
 
-    def test_stream_key_round_trip(self):
-        event = factories.LiveStreamEventFactory.create(stream_key="abcd-1234")
-        event.refresh_from_db()
-        self.assertEqual(event.stream_key, "abcd-1234")
+    def test_clean_rejects_stream_key_from_another_season(self):
+        event = factories.LiveStreamEventFactory.create()
+        other_key = factories.LiveStreamKeyFactory.create()
+        event.stream_key = other_key
+        with self.assertRaises(ValidationError) as cm:
+            event.clean()
+        self.assertIn("stream_key", cm.exception.message_dict)
+
+    def test_clean_accepts_stream_key_from_same_season(self):
+        event = factories.LiveStreamEventFactory.create()
+        event.stream_key = factories.LiveStreamKeyFactory.create(season=event.season)
+        self.assertEqual(event.clean(), None)
 
     def test_thumbnail_prefers_event_image(self):
         event = factories.LiveStreamEventFactory.create(
@@ -83,7 +93,51 @@ class LiveStreamEventModelTests(TestCase):
         self.assertCountEqual(event.season.live_stream_events.all(), [event])
 
 
+class LiveStreamKeyModelTests(TestCase):
+    def test_str_without_generated_key_is_title(self):
+        stream_key = factories.LiveStreamKeyFactory.create(title="Roaming Camera")
+        self.assertEqual(str(stream_key), "Roaming Camera")
+
+    def test_str_with_generated_key_includes_key(self):
+        stream_key = factories.LiveStreamKeyFactory.create(
+            title="Roaming Camera", stream_key="abcd-1234"
+        )
+        self.assertEqual(str(stream_key), "Roaming Camera (abcd-1234)")
+
+    def test_season_relation(self):
+        stream_key = factories.LiveStreamKeyFactory.create()
+        self.assertCountEqual(stream_key.season.live_stream_keys.all(), [stream_key])
+
+    def test_admin_urls(self):
+        stream_key = factories.LiveStreamKeyFactory.create()
+        self.assertEqual(
+            str(stream_key.urls["edit"]),
+            self.reverse(
+                "admin:fixja:competition:season:livestreamkey:edit",
+                stream_key.season.competition_id,
+                stream_key.season_id,
+                stream_key.pk,
+            ),
+        )
+        self.assertCountEqual(stream_key.urls.keys(), ["add", "edit", "delete"])
+
+    def test_protected_while_referenced_by_event(self):
+        stream_key = factories.LiveStreamKeyFactory.create()
+        factories.LiveStreamEventFactory.create(
+            season=stream_key.season, stream_key=stream_key
+        )
+        with self.assertRaises(ProtectedError):
+            stream_key.delete()
+
+
 class LiveStreamEventFormTests(TestCase):
+    def test_stream_key_choices_limited_to_season_pool(self):
+        event = factories.LiveStreamEventFactory.create()
+        stream_key = factories.LiveStreamKeyFactory.create(season=event.season)
+        factories.LiveStreamKeyFactory.create()  # another season entirely
+        form = LiveStreamEventForm(instance=event)
+        self.assertCountEqual(form.fields["stream_key"].queryset, [stream_key])
+
     def test_stop_before_start_is_invalid(self):
         season = factories.SeasonFactory.create()
         form = LiveStreamEventForm(
@@ -105,6 +159,7 @@ class LiveStreamEventFormTests(TestCase):
 
     def test_valid_form_saves_event(self):
         season = factories.SeasonFactory.create()
+        stream_key = factories.LiveStreamKeyFactory.create(season=season)
         form = LiveStreamEventForm(
             instance=LiveStreamEvent(season=season),
             data={
@@ -116,7 +171,7 @@ class LiveStreamEventFormTests(TestCase):
                 "stop_0": "2025-05-01",
                 "stop_1": "20:30:00",
                 "stop_2": "UTC",
-                "stream_key": "abcd-1234",
+                "stream_key": str(stream_key.pk),
                 "live_stream": "1",
             },
         )
@@ -129,7 +184,7 @@ class LiveStreamEventFormTests(TestCase):
         self.assertEqual(
             event.stop, datetime.datetime(2025, 5, 1, 20, 30, tzinfo=UTC)
         )
-        self.assertEqual(event.stream_key, "abcd-1234")
+        self.assertEqual(event.stream_key, stream_key)
 
 
 class BuildLiveStreamEventBodyTests(TestCase):
@@ -198,6 +253,58 @@ class SyncLiveStreamEventTests(TestCase):
         "tournamentcontrol.competition.models.Season.youtube",
         new_callable=mock.PropertyMock,
     )
+    def test_insert_binds_to_selected_stream_key(self, mock_youtube_prop):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        mock_youtube.liveBroadcasts.return_value.insert.return_value.execute.return_value = {
+            "id": "adhoc123"
+        }
+        mock_youtube.liveBroadcasts.return_value.bind.return_value.execute.return_value = {
+            "contentDetails": {"boundStreamId": "stream456"}
+        }
+
+        event = self._event()
+        event.stream_key = factories.LiveStreamKeyFactory.create(
+            season=event.season,
+            external_identifier="stream456",
+            stream_key="abcd-1234",
+        )
+        event.save()
+
+        sync_live_stream_event(event.pk)
+
+        mock_youtube.liveBroadcasts.return_value.bind.assert_called_once_with(
+            part="id,snippet,contentDetails,status",
+            id="adhoc123",
+            streamId="stream456",
+        )
+        event.refresh_from_db()
+        self.assertEqual(event.live_stream_bind, "stream456")
+
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_unbinds_when_stream_key_removed(self, mock_youtube_prop):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+
+        event = self._event(
+            external_identifier="adhoc123", live_stream_bind="stream456"
+        )
+        sync_live_stream_event(event.pk)
+
+        mock_youtube.liveBroadcasts.return_value.bind.assert_called_once_with(
+            part="id,snippet,contentDetails,status",
+            id="adhoc123",
+        )
+        event.refresh_from_db()
+        self.assertEqual(event.live_stream_bind, None)
+
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
     def test_update_existing_broadcast(self, mock_youtube_prop):
         mock_youtube = mock.MagicMock()
         mock_youtube_prop.return_value = mock_youtube
@@ -223,6 +330,7 @@ class SyncLiveStreamEventTests(TestCase):
         event = self._event(
             external_identifier="adhoc123",
             live_stream=False,
+            live_stream_bind="stream456",
         )
         sync_live_stream_event(event.pk)
 
@@ -231,6 +339,7 @@ class SyncLiveStreamEventTests(TestCase):
         )
         event.refresh_from_db()
         self.assertEqual(event.external_identifier, None)
+        self.assertEqual(event.live_stream_bind, None)
 
     @mock.patch(
         "tournamentcontrol.competition.models.Season.youtube",
@@ -438,4 +547,171 @@ class LiveStreamEventAdminTests(TestCase):
             self.response_302()
 
         self.assertEqual(LiveStreamEvent.objects.count(), 0)
+        mock_task.s.assert_not_called()
+
+
+class DeleteYoutubeStreamTests(TestCase):
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_deletes_stream(self, mock_youtube_prop):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+
+        season = factories.SeasonFactory.create(
+            live_stream=True,
+            live_stream_client_id="client-id",
+            live_stream_client_secret="client-secret",
+        )
+        delete_youtube_stream(season.pk, "stream456")
+
+        mock_youtube.liveStreams.return_value.delete.assert_called_once_with(
+            id="stream456"
+        )
+
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_no_credentials_skips_api(self, mock_youtube_prop):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+
+        season = factories.SeasonFactory.create()
+        delete_youtube_stream(season.pk, "stream456")
+
+        mock_youtube.liveStreams.assert_not_called()
+
+
+class LiveStreamKeyAdminTests(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.superuser = UserFactory.create(is_staff=True, is_superuser=True)
+
+    def test_season_edit_lists_stream_keys_when_live_stream_enabled(self):
+        stream_key = factories.LiveStreamKeyFactory.create(
+            title="Roaming Camera", season__live_stream=True
+        )
+        with self.login(self.superuser):
+            self.assertGoodView(
+                "admin:fixja:competition:season:edit",
+                stream_key.season.competition_id,
+                stream_key.season_id,
+            )
+            self.assertResponseContains("Roaming Camera", html=False)
+            self.assertResponseContains("live_stream_keys-tab", html=False)
+
+    def test_edit_view_renders(self):
+        stream_key = factories.LiveStreamKeyFactory.create(season__live_stream=True)
+        with self.login(self.superuser):
+            self.get(
+                "admin:fixja:competition:season:livestreamkey:edit",
+                stream_key.season.competition_id,
+                stream_key.season_id,
+                stream_key.pk,
+            )
+            self.response_200()
+
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_add_stream_key_generates_key_on_youtube(self, mock_youtube_prop):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        mock_youtube.liveStreams.return_value.insert.return_value.execute.return_value = {
+            "id": "stream456",
+            "cdn": {"ingestionInfo": {"streamName": "abcd-1234"}},
+        }
+
+        season = factories.SeasonFactory.create(
+            live_stream=True,
+            live_stream_client_id="client-id",
+            live_stream_client_secret="client-secret",
+        )
+        with self.login(self.superuser):
+            self.post(
+                "admin:fixja:competition:season:livestreamkey:add",
+                season.competition_id,
+                season.pk,
+                data={"title": "Roaming Camera"},
+            )
+            self.response_302()
+
+        stream_key = season.live_stream_keys.get()
+        self.assertEqual(stream_key.title, "Roaming Camera")
+        self.assertEqual(stream_key.external_identifier, "stream456")
+        self.assertEqual(stream_key.stream_key, "abcd-1234")
+
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_add_stream_key_without_credentials_skips_youtube(
+        self, mock_youtube_prop
+    ):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+
+        season = factories.SeasonFactory.create(live_stream=True)
+        with self.login(self.superuser):
+            self.post(
+                "admin:fixja:competition:season:livestreamkey:add",
+                season.competition_id,
+                season.pk,
+                data={"title": "Roaming Camera"},
+            )
+            self.response_302()
+
+        mock_youtube.liveStreams.assert_not_called()
+        stream_key = season.live_stream_keys.get()
+        self.assertEqual(stream_key.stream_key, None)
+        self.assertEqual(stream_key.external_identifier, None)
+
+    @mock.patch("tournamentcontrol.competition.admin.delete_youtube_stream")
+    def test_delete_stream_key_queues_stream_cleanup(self, mock_task):
+        stream_key = factories.LiveStreamKeyFactory.create(
+            season__live_stream=True,
+            season__live_stream_client_id="client-id",
+            season__live_stream_client_secret="client-secret",
+            external_identifier="stream456",
+            stream_key="abcd-1234",
+        )
+        with self.login(self.superuser):
+            self.post(
+                "admin:fixja:competition:season:livestreamkey:delete",
+                stream_key.season.competition_id,
+                stream_key.season_id,
+                stream_key.pk,
+            )
+            self.response_302()
+
+        self.assertEqual(LiveStreamKey.objects.count(), 0)
+        mock_task.s.assert_called_once_with(stream_key.season.pk, "stream456")
+
+    @mock.patch("tournamentcontrol.competition.admin.delete_youtube_stream")
+    def test_delete_stream_key_in_use_is_refused(self, mock_task):
+        stream_key = factories.LiveStreamKeyFactory.create(
+            season__live_stream=True,
+            season__live_stream_client_id="client-id",
+            season__live_stream_client_secret="client-secret",
+            external_identifier="stream456",
+            stream_key="abcd-1234",
+        )
+        factories.LiveStreamEventFactory.create(
+            season=stream_key.season, stream_key=stream_key
+        )
+        with self.login(self.superuser):
+            self.post(
+                "admin:fixja:competition:season:livestreamkey:delete",
+                stream_key.season.competition_id,
+                stream_key.season_id,
+                stream_key.pk,
+            )
+            self.response_302()
+
+        # The record is protected while an event references it, so it must
+        # still exist and no cleanup may be queued against the platform.
+        self.assertEqual(LiveStreamKey.objects.count(), 1)
         mock_task.s.assert_not_called()

--- a/tournamentcontrol/competition/tests/test_live_stream_event.py
+++ b/tournamentcontrol/competition/tests/test_live_stream_event.py
@@ -1,0 +1,510 @@
+"""
+Tests for adhoc live stream events associated with a competition Season.
+"""
+
+import datetime
+from unittest import mock
+from zoneinfo import ZoneInfo
+
+from django.core.exceptions import ValidationError
+from test_plus import TestCase
+
+from touchtechnology.common.tests.factories import UserFactory
+from tournamentcontrol.competition.forms import LiveStreamEventForm
+from tournamentcontrol.competition.models import LiveStreamEvent
+from tournamentcontrol.competition.tasks import (
+    build_live_stream_event_body,
+    delete_youtube_broadcast,
+    sync_live_stream_event,
+)
+from tournamentcontrol.competition.tests import factories
+
+UTC = ZoneInfo("UTC")
+
+
+class LiveStreamEventModelTests(TestCase):
+    def test_str_is_title(self):
+        event = factories.LiveStreamEventFactory.create(title="Opening Ceremony")
+        self.assertEqual(str(event), "Opening Ceremony")
+
+    def test_clean_rejects_stop_before_start(self):
+        event = factories.LiveStreamEventFactory.create()
+        event.stop = event.start - datetime.timedelta(minutes=30)
+        with self.assertRaises(ValidationError) as cm:
+            event.clean()
+        self.assertIn("stop", cm.exception.message_dict)
+
+    def test_clean_rejects_stop_equal_to_start(self):
+        event = factories.LiveStreamEventFactory.create()
+        event.stop = event.start
+        with self.assertRaises(ValidationError) as cm:
+            event.clean()
+        self.assertIn("stop", cm.exception.message_dict)
+
+    def test_clean_rejects_ground_from_another_season(self):
+        event = factories.LiveStreamEventFactory.create()
+        other_ground = factories.GroundFactory.create()
+        event.ground = other_ground
+        with self.assertRaises(ValidationError) as cm:
+            event.clean()
+        self.assertIn("ground", cm.exception.message_dict)
+
+    def test_clean_accepts_ground_from_same_season(self):
+        event = factories.LiveStreamEventFactory.create()
+        ground = factories.GroundFactory.create(venue__season=event.season)
+        event.ground = ground
+        self.assertEqual(event.clean(), None)
+
+    def test_thumbnail_prefers_event_image(self):
+        event = factories.LiveStreamEventFactory.create(
+            season__live_stream_thumbnail_image=b"season-bytes",
+            live_stream_thumbnail_image=b"event-bytes",
+        )
+        media = event.get_thumbnail_media_upload()
+        self.assertEqual(media.getbytes(0, 11), b"event-bytes")
+
+    def test_thumbnail_falls_back_to_season_image(self):
+        event = factories.LiveStreamEventFactory.create(
+            season__live_stream_thumbnail_image=b"season-bytes",
+        )
+        media = event.get_thumbnail_media_upload()
+        self.assertEqual(media.getbytes(0, 12), b"season-bytes")
+
+    def test_thumbnail_none_when_no_images(self):
+        event = factories.LiveStreamEventFactory.create()
+        self.assertEqual(event.get_thumbnail_media_upload(), None)
+
+    def test_admin_urls(self):
+        event = factories.LiveStreamEventFactory.create()
+        self.assertEqual(
+            str(event.urls["edit"]),
+            self.reverse(
+                "admin:fixja:competition:season:livestreamevent:edit",
+                event.season.competition_id,
+                event.season_id,
+                event.pk,
+            ),
+        )
+        self.assertCountEqual(event.urls.keys(), ["add", "edit", "delete"])
+
+    def test_season_relation(self):
+        event = factories.LiveStreamEventFactory.create()
+        self.assertCountEqual(event.season.live_stream_events.all(), [event])
+
+
+class LiveStreamEventFormTests(TestCase):
+    def test_ground_queryset_limited_to_season(self):
+        event = factories.LiveStreamEventFactory.create()
+        ground = factories.GroundFactory.create(venue__season=event.season)
+        factories.GroundFactory.create()  # another season entirely
+        form = LiveStreamEventForm(instance=event)
+        self.assertCountEqual(form.fields["ground"].queryset, [ground])
+
+    def test_stop_before_start_is_invalid(self):
+        season = factories.SeasonFactory.create()
+        form = LiveStreamEventForm(
+            instance=LiveStreamEvent(season=season),
+            data={
+                "title": "Opening Ceremony",
+                "description": "",
+                "start_0": "2025-05-01",
+                "start_1": "19:00:00",
+                "start_2": "UTC",
+                "stop_0": "2025-05-01",
+                "stop_1": "18:00:00",
+                "stop_2": "UTC",
+                "live_stream": "1",
+            },
+        )
+        self.assertEqual(form.is_valid(), False)
+        self.assertIn("stop", form.errors)
+
+    def test_valid_form_saves_event(self):
+        season = factories.SeasonFactory.create()
+        form = LiveStreamEventForm(
+            instance=LiveStreamEvent(season=season),
+            data={
+                "title": "Opening Ceremony",
+                "description": "Live from the main field.",
+                "start_0": "2025-05-01",
+                "start_1": "19:00:00",
+                "start_2": "UTC",
+                "stop_0": "2025-05-01",
+                "stop_1": "20:30:00",
+                "stop_2": "UTC",
+                "live_stream": "1",
+            },
+        )
+        self.assertEqual(form.is_valid(), True, form.errors)
+        event = form.save()
+        self.assertEqual(event.season, season)
+        self.assertEqual(
+            event.start, datetime.datetime(2025, 5, 1, 19, 0, tzinfo=UTC)
+        )
+        self.assertEqual(
+            event.stop, datetime.datetime(2025, 5, 1, 20, 30, tzinfo=UTC)
+        )
+
+
+class BuildLiveStreamEventBodyTests(TestCase):
+    def test_body_uses_event_details(self):
+        event = factories.LiveStreamEventFactory.create(
+            title="Grand Final Presentation",
+            description="Trophy presentation and speeches.",
+            start=datetime.datetime(2025, 5, 3, 6, 0, tzinfo=UTC),
+            stop=datetime.datetime(2025, 5, 3, 7, 30, tzinfo=UTC),
+            season__live_stream_privacy="unlisted",
+        )
+        body = build_live_stream_event_body(event)
+        self.assertEqual(body["snippet"]["title"], "Grand Final Presentation")
+        self.assertEqual(
+            body["snippet"]["description"], "Trophy presentation and speeches."
+        )
+        self.assertEqual(
+            body["snippet"]["scheduledStartTime"], "2025-05-03T06:00:00+00:00"
+        )
+        self.assertEqual(
+            body["snippet"]["scheduledEndTime"], "2025-05-03T07:30:00+00:00"
+        )
+        self.assertEqual(body["status"]["privacyStatus"], "unlisted")
+
+    def test_body_normalises_to_utc(self):
+        sydney = ZoneInfo("Australia/Sydney")
+        event = factories.LiveStreamEventFactory.create(
+            start=datetime.datetime(2025, 5, 3, 16, 0, tzinfo=sydney),
+            stop=datetime.datetime(2025, 5, 3, 17, 0, tzinfo=sydney),
+        )
+        body = build_live_stream_event_body(event)
+        self.assertEqual(
+            body["snippet"]["scheduledStartTime"], "2025-05-03T06:00:00+00:00"
+        )
+        self.assertEqual(
+            body["snippet"]["scheduledEndTime"], "2025-05-03T07:00:00+00:00"
+        )
+
+
+class SyncLiveStreamEventTests(TestCase):
+    def _event(self, **kwargs):
+        kwargs.setdefault("season__live_stream", True)
+        kwargs.setdefault("season__live_stream_client_id", "client-id")
+        kwargs.setdefault("season__live_stream_client_secret", "client-secret")
+        return factories.LiveStreamEventFactory.create(**kwargs)
+
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_insert_sets_external_identifier(self, mock_youtube_prop):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        mock_youtube.liveBroadcasts.return_value.insert.return_value.execute.return_value = {
+            "id": "adhoc123"
+        }
+
+        event = self._event()
+        sync_live_stream_event(event.pk)
+
+        mock_youtube.liveBroadcasts.return_value.insert.assert_called_once()
+        event.refresh_from_db()
+        self.assertEqual(event.external_identifier, "adhoc123")
+
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_insert_binds_to_ground_stream(self, mock_youtube_prop):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        mock_youtube.liveBroadcasts.return_value.insert.return_value.execute.return_value = {
+            "id": "adhoc123"
+        }
+        mock_youtube.liveBroadcasts.return_value.bind.return_value.execute.return_value = {
+            "contentDetails": {"boundStreamId": "stream456"}
+        }
+
+        event = self._event()
+        event.ground = factories.GroundFactory.create(
+            venue__season=event.season,
+            live_stream=True,
+            external_identifier="stream456",
+            stream_key="abcd-1234",
+        )
+        event.save()
+
+        sync_live_stream_event(event.pk)
+
+        mock_youtube.liveBroadcasts.return_value.bind.assert_called_once_with(
+            part="id,snippet,contentDetails,status",
+            id="adhoc123",
+            streamId="stream456",
+        )
+        event.refresh_from_db()
+        self.assertEqual(event.live_stream_bind, "stream456")
+
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_update_existing_broadcast(self, mock_youtube_prop):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+
+        event = self._event(external_identifier="adhoc123")
+        sync_live_stream_event(event.pk)
+
+        mock_youtube.liveBroadcasts.return_value.update.assert_called_once()
+        body = mock_youtube.liveBroadcasts.return_value.update.call_args.kwargs[
+            "body"
+        ]
+        self.assertEqual(body["id"], "adhoc123")
+        mock_youtube.liveBroadcasts.return_value.insert.assert_not_called()
+
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_disable_live_stream_deletes_broadcast(self, mock_youtube_prop):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+
+        event = self._event(
+            external_identifier="adhoc123",
+            live_stream=False,
+            live_stream_bind="stream456",
+        )
+        sync_live_stream_event(event.pk)
+
+        mock_youtube.liveBroadcasts.return_value.delete.assert_called_once_with(
+            id="adhoc123"
+        )
+        event.refresh_from_db()
+        self.assertEqual(event.external_identifier, None)
+        self.assertEqual(event.live_stream_bind, None)
+
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_unbinds_when_ground_removed(self, mock_youtube_prop):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+
+        event = self._event(
+            external_identifier="adhoc123", live_stream_bind="stream456"
+        )
+        sync_live_stream_event(event.pk)
+
+        mock_youtube.liveBroadcasts.return_value.bind.assert_called_once_with(
+            part="id,snippet,contentDetails,status",
+            id="adhoc123",
+        )
+        event.refresh_from_db()
+        self.assertEqual(event.live_stream_bind, None)
+
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_no_credentials_skips_api(self, mock_youtube_prop):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+
+        event = factories.LiveStreamEventFactory.create()
+        sync_live_stream_event(event.pk)
+
+        mock_youtube.liveBroadcasts.assert_not_called()
+
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_returns_quietly_when_event_was_deleted(self, mock_youtube_prop):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+
+        event = self._event()
+        pk = event.pk
+        event.delete()
+        sync_live_stream_event(pk)
+
+        mock_youtube.liveBroadcasts.assert_not_called()
+
+    @mock.patch("tournamentcontrol.competition.tasks.set_live_stream_event_thumbnail")
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_insert_queues_thumbnail_when_available(
+        self, mock_youtube_prop, mock_thumbnail
+    ):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        mock_youtube.liveBroadcasts.return_value.insert.return_value.execute.return_value = {
+            "id": "adhoc123"
+        }
+
+        event = self._event(live_stream_thumbnail_image=b"event-bytes")
+        sync_live_stream_event(event.pk)
+
+        mock_thumbnail.s.assert_called_once_with(event.pk)
+
+
+class DeleteYoutubeBroadcastTests(TestCase):
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_deletes_broadcast(self, mock_youtube_prop):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+
+        season = factories.SeasonFactory.create(
+            live_stream=True,
+            live_stream_client_id="client-id",
+            live_stream_client_secret="client-secret",
+        )
+        delete_youtube_broadcast(season.pk, "adhoc123")
+
+        mock_youtube.liveBroadcasts.return_value.delete.assert_called_once_with(
+            id="adhoc123"
+        )
+
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_no_credentials_skips_api(self, mock_youtube_prop):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+
+        season = factories.SeasonFactory.create()
+        delete_youtube_broadcast(season.pk, "adhoc123")
+
+        mock_youtube.liveBroadcasts.assert_not_called()
+
+
+class LiveStreamEventAdminTests(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.superuser = UserFactory.create(is_staff=True, is_superuser=True)
+
+    def test_season_edit_lists_events_when_live_stream_enabled(self):
+        event = factories.LiveStreamEventFactory.create(
+            title="Opening Ceremony", season__live_stream=True
+        )
+        with self.login(self.superuser):
+            self.assertGoodView(
+                "admin:fixja:competition:season:edit",
+                event.season.competition_id,
+                event.season_id,
+            )
+            self.assertResponseContains("Opening Ceremony", html=False)
+            self.assertResponseContains("live_stream_events-tab", html=False)
+
+    def test_season_edit_hides_events_tab_when_not_live_streamed(self):
+        season = factories.SeasonFactory.create(live_stream=False)
+        with self.login(self.superuser):
+            self.assertGoodView(
+                "admin:fixja:competition:season:edit",
+                season.competition_id,
+                season.pk,
+            )
+            self.assertResponseNotContains("live_stream_events-tab", html=False)
+
+    def test_add_event_requires_login(self):
+        season = factories.SeasonFactory.create(live_stream=True)
+        self.assertLoginRequired(
+            "admin:fixja:competition:season:livestreamevent:add",
+            season.competition_id,
+            season.pk,
+        )
+
+    @mock.patch("tournamentcontrol.competition.admin.sync_live_stream_event")
+    def test_add_event_queues_sync_when_configured(self, mock_task):
+        season = factories.SeasonFactory.create(
+            live_stream=True,
+            live_stream_client_id="client-id",
+            live_stream_client_secret="client-secret",
+        )
+        with self.login(self.superuser):
+            self.post(
+                "admin:fixja:competition:season:livestreamevent:add",
+                season.competition_id,
+                season.pk,
+                data={
+                    "title": "Opening Ceremony",
+                    "description": "",
+                    "start_0": "2025-05-01",
+                    "start_1": "19:00:00",
+                    "start_2": "UTC",
+                    "stop_0": "2025-05-01",
+                    "stop_1": "20:30:00",
+                    "stop_2": "UTC",
+                    "live_stream": "1",
+                },
+            )
+            self.response_302()
+
+        event = season.live_stream_events.get()
+        self.assertEqual(event.title, "Opening Ceremony")
+        mock_task.s.assert_called_once_with(event.pk)
+
+    @mock.patch("tournamentcontrol.competition.admin.sync_live_stream_event")
+    def test_add_event_does_not_queue_sync_without_credentials(self, mock_task):
+        season = factories.SeasonFactory.create(live_stream=True)
+        with self.login(self.superuser):
+            self.post(
+                "admin:fixja:competition:season:livestreamevent:add",
+                season.competition_id,
+                season.pk,
+                data={
+                    "title": "Opening Ceremony",
+                    "description": "",
+                    "start_0": "2025-05-01",
+                    "start_1": "19:00:00",
+                    "start_2": "UTC",
+                    "stop_0": "2025-05-01",
+                    "stop_1": "20:30:00",
+                    "stop_2": "UTC",
+                    "live_stream": "1",
+                },
+            )
+            self.response_302()
+
+        self.assertEqual(season.live_stream_events.count(), 1)
+        mock_task.s.assert_not_called()
+
+    @mock.patch("tournamentcontrol.competition.admin.delete_youtube_broadcast")
+    def test_delete_event_queues_broadcast_cleanup(self, mock_task):
+        event = factories.LiveStreamEventFactory.create(
+            season__live_stream=True,
+            season__live_stream_client_id="client-id",
+            season__live_stream_client_secret="client-secret",
+            external_identifier="adhoc123",
+        )
+        with self.login(self.superuser):
+            self.post(
+                "admin:fixja:competition:season:livestreamevent:delete",
+                event.season.competition_id,
+                event.season_id,
+                event.pk,
+            )
+            self.response_302()
+
+        self.assertEqual(LiveStreamEvent.objects.count(), 0)
+        mock_task.s.assert_called_once_with(event.season.pk, "adhoc123")
+
+    @mock.patch("tournamentcontrol.competition.admin.delete_youtube_broadcast")
+    def test_delete_event_without_broadcast_skips_cleanup(self, mock_task):
+        event = factories.LiveStreamEventFactory.create(season__live_stream=True)
+        with self.login(self.superuser):
+            self.post(
+                "admin:fixja:competition:season:livestreamevent:delete",
+                event.season.competition_id,
+                event.season_id,
+                event.pk,
+            )
+            self.response_302()
+
+        self.assertEqual(LiveStreamEvent.objects.count(), 0)
+        mock_task.s.assert_not_called()

--- a/tournamentcontrol/competition/tests/test_live_stream_event.py
+++ b/tournamentcontrol/competition/tests/test_live_stream_event.py
@@ -8,6 +8,7 @@ from zoneinfo import ZoneInfo
 
 from django.core.exceptions import ValidationError
 from django.db.models import ProtectedError
+from googleapiclient.errors import HttpError
 from test_plus import TestCase
 
 from touchtechnology.common.tests.factories import UserFactory
@@ -22,6 +23,11 @@ from tournamentcontrol.competition.tasks import (
 from tournamentcontrol.competition.tests import factories
 
 UTC = ZoneInfo("UTC")
+
+
+def _http_error(status, message):
+    resp = mock.Mock(status=status, reason=message)
+    return HttpError(resp=resp, content=message.encode())
 
 
 class LiveStreamEventModelTests(TestCase):
@@ -95,7 +101,7 @@ class LiveStreamEventModelTests(TestCase):
 
 class LiveStreamKeyModelTests(TestCase):
     def test_str_without_generated_key_is_title(self):
-        stream_key = factories.LiveStreamKeyFactory.create(title="Roaming Camera")
+        stream_key = LiveStreamKey(title="Roaming Camera")
         self.assertEqual(str(stream_key), "Roaming Camera")
 
     def test_str_with_generated_key_includes_key(self):
@@ -157,11 +163,22 @@ class LiveStreamEventFormTests(TestCase):
         self.assertEqual(form.is_valid(), False)
         self.assertIn("stop", form.errors)
 
+    def test_live_stream_toggle_only_offered_after_creation(self):
+        season = factories.SeasonFactory.create()
+        add_form = LiveStreamEventForm(instance=LiveStreamEvent(season=season))
+        self.assertNotIn("live_stream", add_form.fields)
+        edit_form = LiveStreamEventForm(
+            instance=factories.LiveStreamEventFactory.create(season=season)
+        )
+        self.assertIn("live_stream", edit_form.fields)
+
     def test_valid_form_saves_event(self):
         season = factories.SeasonFactory.create()
         stream_key = factories.LiveStreamKeyFactory.create(season=season)
+        # The admin assigns the broadcast identifier issued by the YouTube
+        # platform before the form is saved; simulate that here.
         form = LiveStreamEventForm(
-            instance=LiveStreamEvent(season=season),
+            instance=LiveStreamEvent(season=season, external_identifier="adhoc999"),
             data={
                 "title": "Opening Ceremony",
                 "description": "Live from the main field.",
@@ -172,11 +189,11 @@ class LiveStreamEventFormTests(TestCase):
                 "stop_1": "20:30:00",
                 "stop_2": "UTC",
                 "stream_key": str(stream_key.pk),
-                "live_stream": "1",
             },
         )
         self.assertEqual(form.is_valid(), True, form.errors)
         event = form.save()
+        self.assertEqual(event.pk, "adhoc999")
         self.assertEqual(event.season, season)
         self.assertEqual(
             event.start, datetime.datetime(2025, 5, 1, 19, 0, tzinfo=UTC)
@@ -235,35 +252,14 @@ class SyncLiveStreamEventTests(TestCase):
         "tournamentcontrol.competition.models.Season.youtube",
         new_callable=mock.PropertyMock,
     )
-    def test_insert_sets_external_identifier(self, mock_youtube_prop):
+    def test_update_binds_to_selected_stream_key(self, mock_youtube_prop):
         mock_youtube = mock.MagicMock()
         mock_youtube_prop.return_value = mock_youtube
-        mock_youtube.liveBroadcasts.return_value.insert.return_value.execute.return_value = {
-            "id": "adhoc123"
-        }
-
-        event = self._event()
-        sync_live_stream_event(event.pk)
-
-        mock_youtube.liveBroadcasts.return_value.insert.assert_called_once()
-        event.refresh_from_db()
-        self.assertEqual(event.external_identifier, "adhoc123")
-
-    @mock.patch(
-        "tournamentcontrol.competition.models.Season.youtube",
-        new_callable=mock.PropertyMock,
-    )
-    def test_insert_binds_to_selected_stream_key(self, mock_youtube_prop):
-        mock_youtube = mock.MagicMock()
-        mock_youtube_prop.return_value = mock_youtube
-        mock_youtube.liveBroadcasts.return_value.insert.return_value.execute.return_value = {
-            "id": "adhoc123"
-        }
         mock_youtube.liveBroadcasts.return_value.bind.return_value.execute.return_value = {
             "contentDetails": {"boundStreamId": "stream456"}
         }
 
-        event = self._event()
+        event = self._event(external_identifier="adhoc123")
         event.stream_key = factories.LiveStreamKeyFactory.create(
             season=event.season,
             external_identifier="stream456",
@@ -337,9 +333,52 @@ class SyncLiveStreamEventTests(TestCase):
         mock_youtube.liveBroadcasts.return_value.delete.assert_called_once_with(
             id="adhoc123"
         )
+        # The record keeps its (never reused) primary key after the
+        # broadcast has been removed from the platform.
         event.refresh_from_db()
-        self.assertEqual(event.external_identifier, None)
+        self.assertEqual(event.external_identifier, "adhoc123")
         self.assertEqual(event.live_stream_bind, None)
+
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_disable_live_stream_tolerates_missing_broadcast(
+        self, mock_youtube_prop
+    ):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        mock_youtube.liveBroadcasts.return_value.delete.return_value.execute.side_effect = _http_error(
+            404, "not found"
+        )
+
+        event = self._event(
+            external_identifier="adhoc123",
+            live_stream=False,
+            live_stream_bind="stream456",
+        )
+        sync_live_stream_event(event.pk)
+
+        event.refresh_from_db()
+        self.assertEqual(event.live_stream_bind, None)
+
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_update_skips_when_broadcast_removed(self, mock_youtube_prop):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        mock_youtube.liveBroadcasts.return_value.update.return_value.execute.side_effect = _http_error(
+            404, "not found"
+        )
+
+        event = self._event(external_identifier="adhoc123")
+        sync_live_stream_event(event.pk)
+
+        # A broadcast that has been removed from the platform cannot be
+        # reinstated under the same identifier; nothing further is synced.
+        mock_youtube.liveBroadcasts.return_value.bind.assert_not_called()
 
     @mock.patch(
         "tournamentcontrol.competition.models.Season.youtube",
@@ -374,14 +413,11 @@ class SyncLiveStreamEventTests(TestCase):
         "tournamentcontrol.competition.models.Season.youtube",
         new_callable=mock.PropertyMock,
     )
-    def test_insert_queues_thumbnail_when_available(
+    def test_update_queues_thumbnail_when_available(
         self, mock_youtube_prop, mock_thumbnail
     ):
         mock_youtube = mock.MagicMock()
         mock_youtube_prop.return_value = mock_youtube
-        mock_youtube.liveBroadcasts.return_value.insert.return_value.execute.return_value = {
-            "id": "adhoc123"
-        }
 
         event = self._event(live_stream_thumbnail_image=b"event-bytes")
         sync_live_stream_event(event.pk)
@@ -460,7 +496,19 @@ class LiveStreamEventAdminTests(TestCase):
         )
 
     @mock.patch("tournamentcontrol.competition.admin.sync_live_stream_event")
-    def test_add_event_queues_sync_when_configured(self, mock_task):
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_add_event_creates_broadcast_and_queues_sync(
+        self, mock_youtube_prop, mock_task
+    ):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        mock_youtube.liveBroadcasts.return_value.insert.return_value.execute.return_value = {
+            "id": "adhoc123"
+        }
+
         season = factories.SeasonFactory.create(
             live_stream=True,
             live_stream_client_id="client-id",
@@ -480,17 +528,28 @@ class LiveStreamEventAdminTests(TestCase):
                     "stop_0": "2025-05-01",
                     "stop_1": "20:30:00",
                     "stop_2": "UTC",
-                    "live_stream": "1",
                 },
             )
             self.response_302()
 
+        # The broadcast identifier issued by the platform is the primary key
         event = season.live_stream_events.get()
+        self.assertEqual(event.pk, "adhoc123")
         self.assertEqual(event.title, "Opening Ceremony")
-        mock_task.s.assert_called_once_with(event.pk)
+        mock_youtube.liveBroadcasts.return_value.insert.assert_called_once()
+        mock_task.s.assert_called_once_with("adhoc123")
 
     @mock.patch("tournamentcontrol.competition.admin.sync_live_stream_event")
-    def test_add_event_does_not_queue_sync_without_credentials(self, mock_task):
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_add_event_without_credentials_is_refused(
+        self, mock_youtube_prop, mock_task
+    ):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+
         season = factories.SeasonFactory.create(live_stream=True)
         with self.login(self.superuser):
             self.post(
@@ -506,15 +565,17 @@ class LiveStreamEventAdminTests(TestCase):
                     "stop_0": "2025-05-01",
                     "stop_1": "20:30:00",
                     "stop_2": "UTC",
-                    "live_stream": "1",
                 },
             )
             self.response_302()
 
-        self.assertEqual(season.live_stream_events.count(), 1)
+        self.assertEqual(season.live_stream_events.count(), 0)
+        mock_youtube.liveBroadcasts.assert_not_called()
         mock_task.s.assert_not_called()
 
-    @mock.patch("tournamentcontrol.competition.admin.delete_youtube_broadcast")
+    @mock.patch(
+        "tournamentcontrol.competition.signals.live_streams.delete_youtube_broadcast"
+    )
     def test_delete_event_queues_broadcast_cleanup(self, mock_task):
         event = factories.LiveStreamEventFactory.create(
             season__live_stream=True,
@@ -523,27 +584,31 @@ class LiveStreamEventAdminTests(TestCase):
             external_identifier="adhoc123",
         )
         with self.login(self.superuser):
-            self.post(
-                "admin:fixja:competition:season:livestreamevent:delete",
-                event.season.competition_id,
-                event.season_id,
-                event.pk,
-            )
+            with self.captureOnCommitCallbacks(execute=True):
+                self.post(
+                    "admin:fixja:competition:season:livestreamevent:delete",
+                    event.season.competition_id,
+                    event.season_id,
+                    event.pk,
+                )
             self.response_302()
 
         self.assertEqual(LiveStreamEvent.objects.count(), 0)
         mock_task.s.assert_called_once_with(event.season.pk, "adhoc123")
 
-    @mock.patch("tournamentcontrol.competition.admin.delete_youtube_broadcast")
-    def test_delete_event_without_broadcast_skips_cleanup(self, mock_task):
+    @mock.patch(
+        "tournamentcontrol.competition.signals.live_streams.delete_youtube_broadcast"
+    )
+    def test_delete_event_without_credentials_skips_cleanup(self, mock_task):
         event = factories.LiveStreamEventFactory.create(season__live_stream=True)
         with self.login(self.superuser):
-            self.post(
-                "admin:fixja:competition:season:livestreamevent:delete",
-                event.season.competition_id,
-                event.season_id,
-                event.pk,
-            )
+            with self.captureOnCommitCallbacks(execute=True):
+                self.post(
+                    "admin:fixja:competition:season:livestreamevent:delete",
+                    event.season.competition_id,
+                    event.season_id,
+                    event.pk,
+                )
             self.response_302()
 
         self.assertEqual(LiveStreamEvent.objects.count(), 0)
@@ -639,16 +704,17 @@ class LiveStreamKeyAdminTests(TestCase):
             )
             self.response_302()
 
+        # The liveStream identifier issued by the platform is the primary key
         stream_key = season.live_stream_keys.get()
         self.assertEqual(stream_key.title, "Roaming Camera")
-        self.assertEqual(stream_key.external_identifier, "stream456")
+        self.assertEqual(stream_key.pk, "stream456")
         self.assertEqual(stream_key.stream_key, "abcd-1234")
 
     @mock.patch(
         "tournamentcontrol.competition.models.Season.youtube",
         new_callable=mock.PropertyMock,
     )
-    def test_add_stream_key_without_credentials_skips_youtube(
+    def test_add_stream_key_without_credentials_is_refused(
         self, mock_youtube_prop
     ):
         mock_youtube = mock.MagicMock()
@@ -665,11 +731,11 @@ class LiveStreamKeyAdminTests(TestCase):
             self.response_302()
 
         mock_youtube.liveStreams.assert_not_called()
-        stream_key = season.live_stream_keys.get()
-        self.assertEqual(stream_key.stream_key, None)
-        self.assertEqual(stream_key.external_identifier, None)
+        self.assertEqual(season.live_stream_keys.count(), 0)
 
-    @mock.patch("tournamentcontrol.competition.admin.delete_youtube_stream")
+    @mock.patch(
+        "tournamentcontrol.competition.signals.live_streams.delete_youtube_stream"
+    )
     def test_delete_stream_key_queues_stream_cleanup(self, mock_task):
         stream_key = factories.LiveStreamKeyFactory.create(
             season__live_stream=True,
@@ -679,18 +745,21 @@ class LiveStreamKeyAdminTests(TestCase):
             stream_key="abcd-1234",
         )
         with self.login(self.superuser):
-            self.post(
-                "admin:fixja:competition:season:livestreamkey:delete",
-                stream_key.season.competition_id,
-                stream_key.season_id,
-                stream_key.pk,
-            )
+            with self.captureOnCommitCallbacks(execute=True):
+                self.post(
+                    "admin:fixja:competition:season:livestreamkey:delete",
+                    stream_key.season.competition_id,
+                    stream_key.season_id,
+                    stream_key.pk,
+                )
             self.response_302()
 
         self.assertEqual(LiveStreamKey.objects.count(), 0)
         mock_task.s.assert_called_once_with(stream_key.season.pk, "stream456")
 
-    @mock.patch("tournamentcontrol.competition.admin.delete_youtube_stream")
+    @mock.patch(
+        "tournamentcontrol.competition.signals.live_streams.delete_youtube_stream"
+    )
     def test_delete_stream_key_in_use_is_refused(self, mock_task):
         stream_key = factories.LiveStreamKeyFactory.create(
             season__live_stream=True,
@@ -703,12 +772,13 @@ class LiveStreamKeyAdminTests(TestCase):
             season=stream_key.season, stream_key=stream_key
         )
         with self.login(self.superuser):
-            self.post(
-                "admin:fixja:competition:season:livestreamkey:delete",
-                stream_key.season.competition_id,
-                stream_key.season_id,
-                stream_key.pk,
-            )
+            with self.captureOnCommitCallbacks(execute=True):
+                self.post(
+                    "admin:fixja:competition:season:livestreamkey:delete",
+                    stream_key.season.competition_id,
+                    stream_key.season_id,
+                    stream_key.pk,
+                )
             self.response_302()
 
         # The record is protected while an event references it, so it must

--- a/tournamentcontrol/competition/tests/test_live_stream_event.py
+++ b/tournamentcontrol/competition/tests/test_live_stream_event.py
@@ -458,6 +458,24 @@ class DeleteYoutubeBroadcastTests(TestCase):
 
         mock_youtube.liveBroadcasts.assert_not_called()
 
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_tolerates_already_deleted(self, mock_youtube_prop):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        mock_youtube.liveBroadcasts.return_value.delete.return_value.execute.side_effect = _http_error(
+            404, "not found"
+        )
+
+        season = factories.SeasonFactory.create(
+            live_stream=True,
+            live_stream_client_id="client-id",
+            live_stream_client_secret="client-secret",
+        )
+        self.assertEqual(delete_youtube_broadcast(season.pk, "adhoc123"), None)
+
 
 class LiveStreamEventAdminTests(TestCase):
     def setUp(self):
@@ -576,7 +594,16 @@ class LiveStreamEventAdminTests(TestCase):
     @mock.patch(
         "tournamentcontrol.competition.signals.live_streams.delete_youtube_broadcast"
     )
-    def test_delete_event_queues_broadcast_cleanup(self, mock_task):
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_delete_event_destroys_broadcast_before_removal(
+        self, mock_youtube_prop, mock_task
+    ):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+
         event = factories.LiveStreamEventFactory.create(
             season__live_stream=True,
             season__live_stream_client_id="client-id",
@@ -593,14 +620,61 @@ class LiveStreamEventAdminTests(TestCase):
                 )
             self.response_302()
 
+        mock_youtube.liveBroadcasts.return_value.delete.assert_called_once_with(
+            id="adhoc123"
+        )
         self.assertEqual(LiveStreamEvent.objects.count(), 0)
-        mock_task.s.assert_called_once_with(event.season.pk, "adhoc123")
 
     @mock.patch(
-        "tournamentcontrol.competition.signals.live_streams.delete_youtube_broadcast"
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
     )
-    def test_delete_event_without_credentials_skips_cleanup(self, mock_task):
-        event = factories.LiveStreamEventFactory.create(season__live_stream=True)
+    def test_delete_event_blocked_when_platform_delete_fails(
+        self, mock_youtube_prop
+    ):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        mock_youtube.liveBroadcasts.return_value.delete.return_value.execute.side_effect = _http_error(
+            500, "backend error"
+        )
+
+        event = factories.LiveStreamEventFactory.create(
+            season__live_stream=True,
+            season__live_stream_client_id="client-id",
+            season__live_stream_client_secret="client-secret",
+            external_identifier="adhoc123",
+        )
+        with self.login(self.superuser):
+            self.post(
+                "admin:fixja:competition:season:livestreamevent:delete",
+                event.season.competition_id,
+                event.season_id,
+                event.pk,
+            )
+            self.response_302()
+
+        # Destruction on the platform was not confirmed, the record stays.
+        self.assertEqual(LiveStreamEvent.objects.count(), 1)
+
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_delete_event_proceeds_when_broadcast_already_gone(
+        self, mock_youtube_prop
+    ):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        mock_youtube.liveBroadcasts.return_value.delete.return_value.execute.side_effect = _http_error(
+            404, "not found"
+        )
+
+        event = factories.LiveStreamEventFactory.create(
+            season__live_stream=True,
+            season__live_stream_client_id="client-id",
+            season__live_stream_client_secret="client-secret",
+            external_identifier="adhoc123",
+        )
         with self.login(self.superuser):
             with self.captureOnCommitCallbacks(execute=True):
                 self.post(
@@ -611,8 +685,50 @@ class LiveStreamEventAdminTests(TestCase):
                 )
             self.response_302()
 
+        # Already absent from the platform is equally confirmation.
         self.assertEqual(LiveStreamEvent.objects.count(), 0)
-        mock_task.s.assert_not_called()
+
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_delete_event_without_credentials_is_blocked(self, mock_youtube_prop):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+
+        event = factories.LiveStreamEventFactory.create(season__live_stream=True)
+        with self.login(self.superuser):
+            self.post(
+                "admin:fixja:competition:season:livestreamevent:delete",
+                event.season.competition_id,
+                event.season_id,
+                event.pk,
+            )
+            self.response_302()
+
+        # Without credentials destruction cannot be confirmed, the record
+        # stays and the platform is never touched.
+        mock_youtube.liveBroadcasts.assert_not_called()
+        self.assertEqual(LiveStreamEvent.objects.count(), 1)
+
+    @mock.patch(
+        "tournamentcontrol.competition.signals.live_streams.delete_youtube_broadcast"
+    )
+    def test_model_delete_queues_platform_cleanup(self, mock_broadcast_task):
+        """Deletion outside the admin still queues best-effort cleanup."""
+        event = factories.LiveStreamEventFactory.create(
+            season__live_stream=True,
+            season__live_stream_client_id="client-id",
+            season__live_stream_client_secret="client-secret",
+            external_identifier="adhoc123",
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            event.delete()
+
+        mock_broadcast_task.s.assert_called_once_with(
+            event.season.pk, "adhoc123"
+        )
 
 
 class DeleteYoutubeStreamTests(TestCase):
@@ -647,6 +763,24 @@ class DeleteYoutubeStreamTests(TestCase):
         delete_youtube_stream(season.pk, "stream456")
 
         mock_youtube.liveStreams.assert_not_called()
+
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_tolerates_already_deleted(self, mock_youtube_prop):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        mock_youtube.liveStreams.return_value.delete.return_value.execute.side_effect = _http_error(
+            404, "not found"
+        )
+
+        season = factories.SeasonFactory.create(
+            live_stream=True,
+            live_stream_client_id="client-id",
+            live_stream_client_secret="client-secret",
+        )
+        self.assertEqual(delete_youtube_stream(season.pk, "stream456"), None)
 
 
 class LiveStreamKeyAdminTests(TestCase):
@@ -736,7 +870,16 @@ class LiveStreamKeyAdminTests(TestCase):
     @mock.patch(
         "tournamentcontrol.competition.signals.live_streams.delete_youtube_stream"
     )
-    def test_delete_stream_key_queues_stream_cleanup(self, mock_task):
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_delete_stream_key_destroys_stream_before_removal(
+        self, mock_youtube_prop, mock_task
+    ):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+
         stream_key = factories.LiveStreamKeyFactory.create(
             season__live_stream=True,
             season__live_stream_client_id="client-id",
@@ -754,13 +897,51 @@ class LiveStreamKeyAdminTests(TestCase):
                 )
             self.response_302()
 
+        mock_youtube.liveStreams.return_value.delete.assert_called_once_with(
+            id="stream456"
+        )
         self.assertEqual(LiveStreamKey.objects.count(), 0)
-        mock_task.s.assert_called_once_with(stream_key.season.pk, "stream456")
 
     @mock.patch(
-        "tournamentcontrol.competition.signals.live_streams.delete_youtube_stream"
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
     )
-    def test_delete_stream_key_in_use_is_refused(self, mock_task):
+    def test_delete_stream_key_blocked_when_platform_delete_fails(
+        self, mock_youtube_prop
+    ):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+        mock_youtube.liveStreams.return_value.delete.return_value.execute.side_effect = _http_error(
+            500, "backend error"
+        )
+
+        stream_key = factories.LiveStreamKeyFactory.create(
+            season__live_stream=True,
+            season__live_stream_client_id="client-id",
+            season__live_stream_client_secret="client-secret",
+            external_identifier="stream456",
+            stream_key="abcd-1234",
+        )
+        with self.login(self.superuser):
+            self.post(
+                "admin:fixja:competition:season:livestreamkey:delete",
+                stream_key.season.competition_id,
+                stream_key.season_id,
+                stream_key.pk,
+            )
+            self.response_302()
+
+        # Destruction on the platform was not confirmed, the record stays.
+        self.assertEqual(LiveStreamKey.objects.count(), 1)
+
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_delete_stream_key_in_use_is_refused(self, mock_youtube_prop):
+        mock_youtube = mock.MagicMock()
+        mock_youtube_prop.return_value = mock_youtube
+
         stream_key = factories.LiveStreamKeyFactory.create(
             season__live_stream=True,
             season__live_stream_client_id="client-id",
@@ -772,16 +953,15 @@ class LiveStreamKeyAdminTests(TestCase):
             season=stream_key.season, stream_key=stream_key
         )
         with self.login(self.superuser):
-            with self.captureOnCommitCallbacks(execute=True):
-                self.post(
-                    "admin:fixja:competition:season:livestreamkey:delete",
-                    stream_key.season.competition_id,
-                    stream_key.season_id,
-                    stream_key.pk,
-                )
+            self.post(
+                "admin:fixja:competition:season:livestreamkey:delete",
+                stream_key.season.competition_id,
+                stream_key.season_id,
+                stream_key.pk,
+            )
             self.response_302()
 
         # The record is protected while an event references it, so it must
-        # still exist and no cleanup may be queued against the platform.
+        # still exist and the platform must never be touched.
         self.assertEqual(LiveStreamKey.objects.count(), 1)
-        mock_task.s.assert_not_called()
+        mock_youtube.liveStreams.assert_not_called()


### PR DESCRIPTION
## Summary

Adds the ability to manage **adhoc live stream events** against a competition Season — broadcasts that are not tied to a fixture, such as opening ceremonies, award presentations, or a commentary desk between matches.

**This is a standalone feature.** It has no crossover with the existing match streaming implementation: `Match`, `Ground`, and all related streaming code are untouched, and the migration creates new tables only — no existing schema is altered.

### Models

Migration `0061` — two `CreateModel` operations, purely additive. Both models use the identifier issued by the YouTube platform as their **primary key** — those identifiers are globally unique and never reused, so no surrogate id is needed. Platform resources are therefore created synchronously with the records, and neither can be created unless the season's OAuth2 credentials are configured.

- **`LiveStreamKey`** — a managed pool of stream keys, a unique domain associated to the season and entirely separate from the ground keys used for match streaming:
  - Creating one generates a `liveStream` resource on the YouTube platform and captures the generated `stream_key`; the stream id is the primary key.
  - Keys are `PROTECT`ed while an event references them.
- **`LiveStreamEvent`**:
  - The broadcast is inserted on the platform when the event is created; the broadcast id is the primary key.
  - `season` FK (`related_name="live_stream_events"`).
  - `title` / `description` — author-supplied YouTube snippet content (title capped at 100 chars to match the YouTube limit).
  - `start` / `stop` — explicit scheduled broadcast window using the house `DateTimeField` (date + time + timezone select), with model validation that the finish is after the start.
  - `stream_key` FK into the season's managed pool — presented as a drop-down on the form, limited to the season's own keys (other seasons' keys and ground keys are excluded by construction), validated on the model.
  - `live_stream` toggle — set to No to remove the scheduled broadcast from YouTube while keeping the record under its retired identifier (a removed broadcast cannot be reinstated, so the toggle is only offered after creation).
  - `live_stream_bind` — the bound stream id; `live_stream_thumbnail_image` — per-event thumbnail with fallback to the season thumbnail.

### YouTube integration

- `sync_live_stream_event` — updates or deletes the scheduled broadcast to mirror the event record; binds/unbinds the broadcast to the selected stream key's `liveStream`; queues the thumbnail push when an image is available. Tolerates a 404 for a broadcast that was previously removed.
- `set_live_stream_event_thumbnail` — pushes the event (or fallback season) thumbnail.
- **Guarded deletion**: records are only removed from the database once destruction of the backing resource is confirmed on the YouTube platform. The delete views destroy the resource synchronously first — a 404 (already gone) counts as confirmation; any other API failure or unconfigured credentials blocks the local deletion with an explanatory message, so nothing can be orphaned on the platform with no way to remove it. The object-level permission check is mirrored ahead of the platform call. A `post_delete` signal remains as a best-effort cleanup net for deletions outside the admin, with 404-tolerant tasks.

### Admin (the bulk of the feature)

- New `livestreamevent` and `livestreamkey` namespaces under the season (`.../seasons/<id>/live-stream-event/`, `.../seasons/<id>/stream-key/` add/edit/delete) with string primary keys in the routes, following the same `generic_edit`/`generic_delete` + guardian permission patterns as timeslots and exclusion dates.
- "Live stream events" and "Stream keys" tabs on the season edit view via the `related` whitelist — only added when `season.live_stream` is enabled, so non-streaming seasons are untouched.
- Creation flows fail with a clear error when the season's OAuth2 credentials are not configured; the platform insert happens in `pre_save_callback` so the identifier is available as the primary key at save time.
- A stream key still referenced by events short-circuits to the `generic_delete` `ProtectedError` refusal without touching the platform.

### Safety of the new relations

Every `generic_edit` call passes an explicit `related` whitelist, so no other admin edit view picks up the new reverse relations. The two new edit views pass `related=()` themselves — enumerating the `LiveStreamKey → LiveStreamEvent` reverse relation as a tab would attempt to reverse a nested namespace that isn't routed (caught by test coverage). Both `object|related:related` template loops are guarded by `{% if object.pk %}`, so unsaved-instance add views are unaffected. Both models omit `perms` from their admin URL names since no per-object permissions view is routed.

## Test plan

- [x] Tests in `test_live_stream_event.py` (55): model validation (window, cross-season key), key label/protection, thumbnail fallback, admin URLs, form drop-down domain and toggle-only-on-edit, YouTube body building (UTC normalisation, privacy), sync task update/delete/bind/unbind paths incl. 404 tolerance with mocked API, cleanup tasks, and admin views (tab visibility, synchronous platform creation, credential refusal, guarded deletion incl. blocked-on-failure, already-gone, no-credentials, and protected-key paths, signal cleanup for non-admin deletion).
- [x] `GoodViewTests.test_livestreamevent` / `test_livestreamkey` namespace coverage (add/edit/delete + login required).
- [x] `makemigrations --check` — zero drift for the new models.
- [x] Full `tournamentcontrol.competition` suite plus all `touchtechnology.*` modules run green (Django 5.2 / py3.13 / postgres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1Hyp8Ui51TB1Fs6c4iy4q