### PR TITLE
Component selects and implied season timezone for live stream event times

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -16,6 +16,20 @@ def browser_context_args():
 
 
 @pytest.fixture(scope="session")
+def browser_type_launch_args(browser_type_launch_args):
+    """
+    Allow environments with a pre-installed browser to run the E2E suite
+    without downloading one, by pointing PLAYWRIGHT_CHROMIUM_EXECUTABLE at
+    the browser binary. CI is unaffected -- it installs the browser
+    matching the pinned Playwright version.
+    """
+    executable = os.environ.get("PLAYWRIGHT_CHROMIUM_EXECUTABLE")
+    if executable:
+        return {**browser_type_launch_args, "executable_path": executable}
+    return browser_type_launch_args
+
+
+@pytest.fixture(scope="session")
 def screenshot_dir():
     """
     Create and return the directory for storing test screenshots.

--- a/tests/e2e/test_live_stream_event.py
+++ b/tests/e2e/test_live_stream_event.py
@@ -99,6 +99,19 @@ class TestLiveStreamEventForm:
             "Roaming Camera"
         )
 
+        # Layout: the date components share one line, the time components
+        # the next, rather than each select stacking full width.
+        day = page.locator('select[name="start_0_day"]').bounding_box()
+        month = page.locator('select[name="start_0_month"]').bounding_box()
+        year = page.locator('select[name="start_0_year"]').bounding_box()
+        hour = page.locator('select[name="start_1"]').bounding_box()
+        minute = page.locator('select[name="start_2"]').bounding_box()
+
+        assert abs(day["y"] - month["y"]) < 5
+        assert abs(month["y"] - year["y"]) < 5
+        assert abs(hour["y"] - minute["y"]) < 5
+        assert hour["y"] > day["y"]
+
         page.screenshot(
             path=str(screenshot_dir / "live_stream_event_form.png"), full_page=True
         )

--- a/tests/e2e/test_live_stream_event.py
+++ b/tests/e2e/test_live_stream_event.py
@@ -1,0 +1,136 @@
+"""E2E tests for the adhoc live stream event admin forms."""
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from tournamentcontrol.competition.tests.factories import (
+    LiveStreamEventFactory,
+    LiveStreamKeyFactory,
+    SeasonFactory,
+)
+
+
+class TestLiveStreamEventForm:
+    """Tests for the season live stream event add/edit form.
+
+    The scheduled start and finish are entered with individual component
+    selects (year/month/day/hour/minute) and there is deliberately no
+    timezone input -- times are implied to be in the season's timezone.
+    """
+
+    @pytest.fixture
+    def live_stream_season(self, db):
+        """A live-streamed season with a managed stream key and one event."""
+        season = SeasonFactory.create(
+            title="Test Season",
+            timezone="Australia/Sydney",
+            live_stream=True,
+        )
+        stream_key = LiveStreamKeyFactory.create(
+            season=season, title="Roaming Camera"
+        )
+        event = LiveStreamEventFactory.create(
+            season=season,
+            title="Opening Ceremony",
+            stream_key=stream_key,
+        )
+        return {"season": season, "stream_key": stream_key, "event": event}
+
+    def _season_url(self, live_server, season):
+        return (
+            f"{live_server.url}/admin/fixja/competition/"
+            f"{season.competition.pk}/seasons/{season.pk}/"
+        )
+
+    def test_season_edit_shows_live_stream_tabs(
+        self, authenticated_page: Page, live_server, live_stream_season, screenshot_dir
+    ):
+        """
+        The season edit page must offer the "Live stream events" and
+        "Stream keys" tabs when the season has live streaming enabled.
+        """
+        page = authenticated_page
+        season = live_stream_season["season"]
+
+        page.goto(self._season_url(live_server, season))
+
+        expect(page.locator('a[href="#live_stream_events-tab"]')).to_be_attached()
+        expect(page.locator('a[href="#live_stream_keys-tab"]')).to_be_attached()
+
+        page.locator('a[href="#live_stream_events-tab"]').click()
+        expect(page.locator("#live_stream_events-tab")).to_contain_text(
+            "Opening Ceremony"
+        )
+        page.screenshot(
+            path=str(screenshot_dir / "live_stream_event_season_tab.png"),
+            full_page=True,
+        )
+
+    def test_event_form_uses_component_selects_without_timezone(
+        self, authenticated_page: Page, live_server, live_stream_season, screenshot_dir
+    ):
+        """
+        The add form must present the scheduled start and finish as
+        component selects, with no timezone input and help text naming
+        the season's (implied) timezone.
+        """
+        page = authenticated_page
+        season = live_stream_season["season"]
+
+        page.goto(self._season_url(live_server, season) + "live-stream-event/add/")
+
+        # Date and time entry is via selects, not text inputs.
+        for prefix in ("start", "stop"):
+            expect(page.locator(f'select[name="{prefix}_0_year"]')).to_be_visible()
+            expect(page.locator(f'select[name="{prefix}_0_month"]')).to_be_visible()
+            expect(page.locator(f'select[name="{prefix}_0_day"]')).to_be_visible()
+            expect(page.locator(f'select[name="{prefix}_1"]')).to_be_visible()
+            expect(page.locator(f'select[name="{prefix}_2"]')).to_be_visible()
+            # No timezone component is offered.
+            expect(page.locator(f'select[name="{prefix}_3"]')).to_have_count(0)
+
+        # The implied timezone is stated to the user.
+        expect(page.locator("form")).to_contain_text(
+            "Local time in Australia/Sydney."
+        )
+
+        # The stream key drop-down offers the season's managed pool.
+        expect(page.locator('select[name="stream_key"]')).to_contain_text(
+            "Roaming Camera"
+        )
+
+        page.screenshot(
+            path=str(screenshot_dir / "live_stream_event_form.png"), full_page=True
+        )
+
+    def test_edit_form_renders_times_in_season_timezone(
+        self, authenticated_page: Page, live_server, live_stream_season, screenshot_dir
+    ):
+        """
+        Editing an existing event must render its scheduled times
+        season-local in the component selects.
+        """
+        page = authenticated_page
+        season = live_stream_season["season"]
+        event = live_stream_season["event"]
+
+        page.goto(
+            self._season_url(live_server, season)
+            + f"live-stream-event/{event.pk}/"
+        )
+
+        start_local = event.start.astimezone(season.timezone)
+        expect(page.locator('select[name="start_0_year"]')).to_have_value(
+            str(start_local.year)
+        )
+        expect(page.locator('select[name="start_1"]')).to_have_value(
+            str(start_local.hour)
+        )
+        expect(page.locator('select[name="start_2"]')).to_have_value(
+            str(start_local.minute)
+        )
+
+        page.screenshot(
+            path=str(screenshot_dir / "live_stream_event_form_edit.png"),
+            full_page=True,
+        )

--- a/tournamentcontrol/competition/forms.py
+++ b/tournamentcontrol/competition/forms.py
@@ -343,9 +343,15 @@ class SeasonTimezoneDateTimeWidget(forms.MultiWidget):
     """
     Date and time entry using individual component selects.
 
-    There is deliberately no timezone component — values are interpreted in
-    the timezone assigned to the widget (the season's timezone).
+    The date components render on one line and the time components on the
+    next. There is deliberately no timezone component — values are
+    interpreted in the timezone assigned to the widget (the season's
+    timezone).
     """
+
+    template_name = (
+        "tournamentcontrol/competition/widgets/season_timezone_datetime_widget.html"
+    )
 
     def __init__(self, attrs=None):
         this_year = datetime.date.today().year

--- a/tournamentcontrol/competition/forms.py
+++ b/tournamentcontrol/competition/forms.py
@@ -31,6 +31,7 @@ from django.forms.models import (
     modelformset_factory,
 )
 from django.urls import reverse_lazy
+from django.utils import timezone
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _, ngettext
 from first import first
@@ -336,6 +337,80 @@ class ThumbnailImageField(forms.FileField):
         if hasattr(data, "read"):  # New file uploaded
             return True
         return False
+
+
+class SeasonTimezoneDateTimeWidget(forms.MultiWidget):
+    """
+    Date and time entry using individual component selects.
+
+    There is deliberately no timezone component — values are interpreted in
+    the timezone assigned to the widget (the season's timezone).
+    """
+
+    def __init__(self, attrs=None):
+        this_year = datetime.date.today().year
+        widgets = (
+            forms.SelectDateWidget(
+                attrs=attrs, years=range(this_year - 5, this_year + 5)
+            ),
+            forms.Select(
+                attrs=attrs, choices=[(h, "%02d" % h) for h in range(24)]
+            ),
+            forms.Select(
+                attrs=attrs, choices=[(m, "%02d" % m) for m in range(60)]
+            ),
+        )
+        super().__init__(widgets, attrs)
+        self.timezone = None
+
+    def decompress(self, value):
+        if value:
+            if self.timezone is not None:
+                value = value.astimezone(self.timezone)
+            return [value.date(), value.hour, value.minute]
+        return [None, None, None]
+
+
+class SeasonTimezoneDateTimeField(forms.MultiValueField):
+    """
+    Date and time entry in the timezone of the season.
+
+    The timezone select is deliberately omitted — for practical purposes an
+    adhoc live stream event is always expressed in the timezone of the
+    season it belongs to, so it is implied rather than asked for.
+    """
+
+    widget = SeasonTimezoneDateTimeWidget
+
+    def __init__(self, **kwargs):
+        fields = (
+            forms.DateField(),
+            forms.TypedChoiceField(
+                coerce=int, choices=[(h, "%02d" % h) for h in range(24)]
+            ),
+            forms.TypedChoiceField(
+                coerce=int, choices=[(m, "%02d" % m) for m in range(60)]
+            ),
+        )
+        super().__init__(fields, **kwargs)
+        self._timezone = None
+
+    @property
+    def timezone(self):
+        return self._timezone
+
+    @timezone.setter
+    def timezone(self, value):
+        self._timezone = value
+        self.widget.timezone = value
+
+    def compress(self, data_list):
+        if data_list:
+            value = datetime.datetime.combine(
+                data_list[0], datetime.time(data_list[1], data_list[2])
+            )
+            return timezone.make_aware(value, self.timezone)
+        return None
 
 
 class ConstructFormMixin(object):
@@ -1431,6 +1506,8 @@ class LiveStreamEventForm(BootstrapFormControlMixin, ModelForm):
             ),
         }
         field_classes = {
+            "start": SeasonTimezoneDateTimeField,
+            "stop": SeasonTimezoneDateTimeField,
             "live_stream_thumbnail_image": ThumbnailImageField,
         }
 
@@ -1445,6 +1522,15 @@ class LiveStreamEventForm(BootstrapFormControlMixin, ModelForm):
         # event exists.
         if not self.instance.pk:
             self.fields.pop("live_stream")
+        # Times are always expressed in the season's timezone; it is implied
+        # rather than asked for.
+        tz = self.instance.season.timezone or timezone.get_current_timezone()
+        for name in ("start", "stop"):
+            self.fields[name].timezone = tz
+            self.fields[name].help_text = "{} {}".format(
+                self.fields[name].help_text,
+                _("Local time in %s.") % tz,
+            )
 
 
 class MatchScheduleForm(BaseMatchFormMixin, ModelForm):

--- a/tournamentcontrol/competition/templates/tournamentcontrol/competition/widgets/season_timezone_datetime_widget.html
+++ b/tournamentcontrol/competition/templates/tournamentcontrol/competition/widgets/season_timezone_datetime_widget.html
@@ -1,0 +1,10 @@
+{% with date=widget.subwidgets.0 hour=widget.subwidgets.1 minute=widget.subwidgets.2 %}
+<div class="season-timezone-datetime">
+	<div class="form-inline season-timezone-datetime-date">
+		{% include date.template_name with widget=date only %}
+	</div>
+	<div class="form-inline season-timezone-datetime-time">
+		{% include hour.template_name with widget=hour only %}<span class="season-timezone-datetime-separator">:</span>{% include minute.template_name with widget=minute only %}
+	</div>
+</div>
+{% endwith %}

--- a/tournamentcontrol/competition/tests/test_live_stream_event.py
+++ b/tournamentcontrol/competition/tests/test_live_stream_event.py
@@ -145,19 +145,22 @@ class LiveStreamEventFormTests(TestCase):
         self.assertCountEqual(form.fields["stream_key"].queryset, [stream_key])
 
     def test_stop_before_start_is_invalid(self):
-        season = factories.SeasonFactory.create()
+        season = factories.SeasonFactory.create(timezone="UTC")
         form = LiveStreamEventForm(
             instance=LiveStreamEvent(season=season),
             data={
                 "title": "Opening Ceremony",
                 "description": "",
-                "start_0": "2025-05-01",
-                "start_1": "19:00:00",
-                "start_2": "UTC",
-                "stop_0": "2025-05-01",
-                "stop_1": "18:00:00",
-                "stop_2": "UTC",
-                "live_stream": "1",
+                "start_0_year": "2025",
+                "start_0_month": "5",
+                "start_0_day": "1",
+                "start_1": "19",
+                "start_2": "0",
+                "stop_0_year": "2025",
+                "stop_0_month": "5",
+                "stop_0_day": "1",
+                "stop_1": "18",
+                "stop_2": "0",
             },
         )
         self.assertEqual(form.is_valid(), False)
@@ -173,7 +176,7 @@ class LiveStreamEventFormTests(TestCase):
         self.assertIn("live_stream", edit_form.fields)
 
     def test_valid_form_saves_event(self):
-        season = factories.SeasonFactory.create()
+        season = factories.SeasonFactory.create(timezone="UTC")
         stream_key = factories.LiveStreamKeyFactory.create(season=season)
         # The admin assigns the broadcast identifier issued by the YouTube
         # platform before the form is saved; simulate that here.
@@ -182,12 +185,16 @@ class LiveStreamEventFormTests(TestCase):
             data={
                 "title": "Opening Ceremony",
                 "description": "Live from the main field.",
-                "start_0": "2025-05-01",
-                "start_1": "19:00:00",
-                "start_2": "UTC",
-                "stop_0": "2025-05-01",
-                "stop_1": "20:30:00",
-                "stop_2": "UTC",
+                "start_0_year": "2025",
+                "start_0_month": "5",
+                "start_0_day": "1",
+                "start_1": "19",
+                "start_2": "0",
+                "stop_0_year": "2025",
+                "stop_0_month": "5",
+                "stop_0_day": "1",
+                "stop_1": "20",
+                "stop_2": "30",
                 "stream_key": str(stream_key.pk),
             },
         )
@@ -202,6 +209,62 @@ class LiveStreamEventFormTests(TestCase):
             event.stop, datetime.datetime(2025, 5, 1, 20, 30, tzinfo=UTC)
         )
         self.assertEqual(event.stream_key, stream_key)
+
+    def test_times_are_implied_in_season_timezone(self):
+        sydney = ZoneInfo("Australia/Sydney")
+        season = factories.SeasonFactory.create(timezone="Australia/Sydney")
+        form = LiveStreamEventForm(
+            instance=LiveStreamEvent(season=season, external_identifier="adhoc998"),
+            data={
+                "title": "Opening Ceremony",
+                "description": "",
+                "start_0_year": "2025",
+                "start_0_month": "5",
+                "start_0_day": "1",
+                "start_1": "19",
+                "start_2": "0",
+                "stop_0_year": "2025",
+                "stop_0_month": "5",
+                "stop_0_day": "1",
+                "stop_1": "20",
+                "stop_2": "30",
+            },
+        )
+        self.assertEqual(form.is_valid(), True, form.errors)
+        event = form.save()
+        # Entered as 19:00 with no timezone component — implied Sydney time.
+        self.assertEqual(
+            event.start,
+            datetime.datetime(2025, 5, 1, 19, 0, tzinfo=sydney),
+        )
+        self.assertEqual(
+            event.start.astimezone(UTC),
+            datetime.datetime(2025, 5, 1, 9, 0, tzinfo=UTC),
+        )
+
+    def test_initial_values_render_in_season_timezone(self):
+        season = factories.SeasonFactory.create(timezone="Australia/Sydney")
+        event = factories.LiveStreamEventFactory.create(
+            season=season,
+            start=datetime.datetime(2025, 5, 1, 6, 0, tzinfo=UTC),
+            stop=datetime.datetime(2025, 5, 1, 7, 30, tzinfo=UTC),
+        )
+        form = LiveStreamEventForm(instance=event)
+        # 06:00 UTC is 16:00 in Sydney — components display season-local.
+        self.assertEqual(
+            form.fields["start"].widget.decompress(event.start),
+            [datetime.date(2025, 5, 1), 16, 0],
+        )
+        self.assertEqual(
+            form.fields["stop"].widget.decompress(event.stop),
+            [datetime.date(2025, 5, 1), 17, 30],
+        )
+
+    def test_help_text_names_the_season_timezone(self):
+        season = factories.SeasonFactory.create(timezone="Australia/Sydney")
+        form = LiveStreamEventForm(instance=LiveStreamEvent(season=season))
+        self.assertIn("Australia/Sydney", form.fields["start"].help_text)
+        self.assertIn("Australia/Sydney", form.fields["stop"].help_text)
 
 
 class BuildLiveStreamEventBodyTests(TestCase):
@@ -540,12 +603,16 @@ class LiveStreamEventAdminTests(TestCase):
                 data={
                     "title": "Opening Ceremony",
                     "description": "",
-                    "start_0": "2025-05-01",
-                    "start_1": "19:00:00",
-                    "start_2": "UTC",
-                    "stop_0": "2025-05-01",
-                    "stop_1": "20:30:00",
-                    "stop_2": "UTC",
+                    "start_0_year": "2025",
+                    "start_0_month": "5",
+                    "start_0_day": "1",
+                    "start_1": "19",
+                    "start_2": "0",
+                    "stop_0_year": "2025",
+                    "stop_0_month": "5",
+                    "stop_0_day": "1",
+                    "stop_1": "20",
+                    "stop_2": "30",
                 },
             )
             self.response_302()
@@ -577,12 +644,16 @@ class LiveStreamEventAdminTests(TestCase):
                 data={
                     "title": "Opening Ceremony",
                     "description": "",
-                    "start_0": "2025-05-01",
-                    "start_1": "19:00:00",
-                    "start_2": "UTC",
-                    "stop_0": "2025-05-01",
-                    "stop_1": "20:30:00",
-                    "stop_2": "UTC",
+                    "start_0_year": "2025",
+                    "start_0_month": "5",
+                    "start_0_day": "1",
+                    "start_1": "19",
+                    "start_2": "0",
+                    "stop_0_year": "2025",
+                    "stop_0_month": "5",
+                    "stop_0_day": "1",
+                    "stop_1": "20",
+                    "stop_2": "30",
                 },
             )
             self.response_302()


### PR DESCRIPTION
## Summary

UX refinement for adhoc live stream event scheduling (follow-up to #305):

- **Component selects instead of text inputs** — `start` and `stop` are now entered via a new `SeasonTimezoneDateTimeField` / `SeasonTimezoneDateTimeWidget`: year/month/day through Django's `SelectDateWidget` plus hour and minute selects (year range spans the current year ±5).
- **Timezone is implied, not asked for** — the timezone component is removed entirely. Entered times are interpreted in the season's timezone (falling back to the active timezone when the season doesn't declare one); it would practically never be required to express an event time in any other timezone. The field help text names the timezone in effect (e.g. "Local time in Australia/Sydney."), and initial values on the edit form render season-local.

Form-level change only — the model still stores aware datetimes, YouTube sync still normalises to UTC, and no schema or migration is touched.

Also adds **E2E coverage with screenshots**: three Playwright tests exercise the season tabs, the add form (component selects, no timezone input, implied-timezone help text, stream key drop-down), and the edit form rendering stored times season-local. Each captures a full-page screenshot into `SCREENSHOTS_DIR`, which the e2e workflow already uploads as the `e2e-test-screenshots` artifact — so every CI run on this area now produces reviewable UI images. A `PLAYWRIGHT_CHROMIUM_EXECUTABLE` override in the e2e conftest lets environments with a pre-installed browser run the suite without downloading one (CI unaffected).

## Test plan

- [x] New unit tests: entered components are interpreted in the season's timezone (Sydney 19:00 → 09:00 UTC), initial values decompress season-local (06:00 UTC → 16:00 Sydney components), help text names the timezone.
- [x] Existing form/admin tests updated to the component POST format; full `tournamentcontrol.competition` suite green locally (Django 5.2 / py3.13 / postgres).
- [x] E2E tests pass locally against the live server with screenshots captured; in CI they publish to the `e2e-test-screenshots` artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1Hyp8Ui51TB1Fs6c4iy4q