### PR TITLE
Hold the event datetime layout on mobile viewports

### DIFF
--- a/tests/e2e/test_live_stream_event.py
+++ b/tests/e2e/test_live_stream_event.py
@@ -100,7 +100,22 @@ class TestLiveStreamEventForm:
         )
 
         # Layout: the date components share one line, the time components
-        # the next, rather than each select stacking full width.
+        # the next, rather than each select stacking full width. This must
+        # hold on every viewport, not just desktop.
+        self._assert_date_line_time_line(page)
+        page.screenshot(
+            path=str(screenshot_dir / "live_stream_event_form.png"), full_page=True
+        )
+
+        # Mobile viewport.
+        page.set_viewport_size({"width": 375, "height": 812})
+        self._assert_date_line_time_line(page)
+        page.screenshot(
+            path=str(screenshot_dir / "live_stream_event_form_mobile.png"),
+            full_page=True,
+        )
+
+    def _assert_date_line_time_line(self, page: Page):
         day = page.locator('select[name="start_0_day"]').bounding_box()
         month = page.locator('select[name="start_0_month"]').bounding_box()
         year = page.locator('select[name="start_0_year"]').bounding_box()
@@ -111,10 +126,6 @@ class TestLiveStreamEventForm:
         assert abs(month["y"] - year["y"]) < 5
         assert abs(hour["y"] - minute["y"]) < 5
         assert hour["y"] > day["y"]
-
-        page.screenshot(
-            path=str(screenshot_dir / "live_stream_event_form.png"), full_page=True
-        )
 
     def test_edit_form_renders_times_in_season_timezone(
         self, authenticated_page: Page, live_server, live_stream_season, screenshot_dir

--- a/tournamentcontrol/competition/templates/tournamentcontrol/competition/widgets/season_timezone_datetime_widget.html
+++ b/tournamentcontrol/competition/templates/tournamentcontrol/competition/widgets/season_timezone_datetime_widget.html
@@ -1,9 +1,26 @@
 {% with date=widget.subwidgets.0 hour=widget.subwidgets.1 minute=widget.subwidgets.2 %}
+<style>
+	/* Bootstrap's .form-inline only applies at desktop widths; the
+	   date-line/time-line grouping must hold on every viewport. */
+	.season-timezone-datetime .form-control {
+		display: inline-block;
+		width: auto;
+		vertical-align: middle;
+	}
+	.season-timezone-datetime-date,
+	.season-timezone-datetime-time {
+		margin-bottom: 5px;
+		white-space: nowrap;
+	}
+	.season-timezone-datetime-separator {
+		margin: 0 4px;
+	}
+</style>
 <div class="season-timezone-datetime">
-	<div class="form-inline season-timezone-datetime-date">
+	<div class="season-timezone-datetime-date">
 		{% include date.template_name with widget=date only %}
 	</div>
-	<div class="form-inline season-timezone-datetime-time">
+	<div class="season-timezone-datetime-time">
 		{% include hour.template_name with widget=hour only %}<span class="season-timezone-datetime-separator">:</span>{% include minute.template_name with widget=minute only %}
 	</div>
 </div>


### PR DESCRIPTION
## Summary

Fixes the live stream event datetime layout on phones (follow-up to #307). The date-line/time-line grouping relied on Bootstrap's `.form-inline`, which only applies at desktop widths — on mobile every select fell back to full-width stacking with an orphaned `:` separator. The widget template now styles the grouping itself so it holds at every viewport: date components inline on one line, hour`:`minute on the next.

## Test plan

- [x] The e2e layout assertions now run at both the desktop viewport and a 375×812 mobile viewport (bounding-box checks that the date selects share a line, hour/minute share the next), with a mobile screenshot captured alongside the desktop one in the `e2e-test-screenshots` artifact.
- [x] Full e2e module and unit test module green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1Hyp8Ui51TB1Fs6c4iy4q

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1Hyp8Ui51TB1Fs6c4iy4q)_