### PR TITLE
Handle expired YouTube authorisation gracefully in event admin

### DIFF
--- a/tests/e2e/test_live_stream_event.py
+++ b/tests/e2e/test_live_stream_event.py
@@ -1,5 +1,7 @@
 """E2E tests for the adhoc live stream event admin forms."""
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 from playwright.sync_api import Page, expect
 
@@ -29,10 +31,19 @@ class TestLiveStreamEventForm:
         stream_key = LiveStreamKeyFactory.create(
             season=season, title="Roaming Camera"
         )
+        # The factory would otherwise draw a random start as far back as
+        # 2020, which can fall outside the year select's range (current
+        # year +/- 5). Anchor the schedule near today so the components
+        # always have matching options.
+        start = datetime.now(timezone.utc).replace(
+            minute=30, second=0, microsecond=0
+        ) + timedelta(days=7)
         event = LiveStreamEventFactory.create(
             season=season,
             title="Opening Ceremony",
             stream_key=stream_key,
+            start=start,
+            stop=start + timedelta(hours=2),
         )
         return {"season": season, "stream_key": stream_key, "event": event}
 

--- a/tournamentcontrol/competition/admin.py
+++ b/tournamentcontrol/competition/admin.py
@@ -22,6 +22,7 @@ from django.template.response import TemplateResponse
 from django.urls import include, path, re_path, reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _, ngettext
+from google.auth.exceptions import RefreshError
 from googleapiclient.errors import HttpError
 from guardian.utils import get_40x_or_None
 
@@ -125,6 +126,13 @@ from tournamentcontrol.competition.utils import (
 from tournamentcontrol.competition.wizards import DrawGenerationWizard
 
 SCORECARD_PDF_WAIT = getattr(settings, "TOURNAMENTCONTROL_SCORECARD_PDF_WAIT", 5)
+
+# Shown when the season's stored OAuth2 refresh token is expired or revoked
+# and the YouTube platform can no longer be reached on its behalf.
+YOUTUBE_AUTH_EXPIRED_MESSAGE = _(
+    "YouTube authorisation for this season has expired or been revoked. "
+    "Re-authorise from the YouTube button on the seasons list and try again."
+)
 
 log = logging.getLogger(__name__)
 
@@ -1617,6 +1625,9 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
                     )
                     .execute()
                 )
+            except RefreshError:
+                messages.error(request, YOUTUBE_AUTH_EXPIRED_MESSAGE)
+                return self.redirect(".")
             except HttpError as exc:
                 messages.error(request, exc.reason)
                 return self.redirect(".")
@@ -1694,6 +1705,11 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
                 id=instance.pk
             ).execute()
             log.info("YouTube resource %r deleted", instance.pk)
+        except RefreshError:
+            # Destruction cannot be confirmed without authorisation, so the
+            # record must be retained.
+            messages.error(request, YOUTUBE_AUTH_EXPIRED_MESSAGE)
+            return redirect_response
         except HttpError as exc:
             if getattr(exc.resp, "status", None) != 404:
                 messages.error(request, exc.reason)
@@ -1788,6 +1804,9 @@ class CompetitionAdminComponent(CompetitionAdminMixin, AdminComponent):
 
                 obj.stream_key = stream["cdn"]["ingestionInfo"]["streamName"]
 
+            except RefreshError:
+                messages.error(request, YOUTUBE_AUTH_EXPIRED_MESSAGE)
+                return self.redirect(".")
             except HttpError as exc:
                 messages.error(request, exc.reason)
                 return self.redirect(".")

--- a/tournamentcontrol/competition/tests/test_live_stream_event.py
+++ b/tournamentcontrol/competition/tests/test_live_stream_event.py
@@ -6,8 +6,10 @@ import datetime
 from unittest import mock
 from zoneinfo import ZoneInfo
 
+from django.contrib.messages import get_messages
 from django.core.exceptions import ValidationError
 from django.db.models import ProtectedError
+from google.auth.exceptions import RefreshError
 from googleapiclient.errors import HttpError
 from test_plus import TestCase
 
@@ -783,6 +785,83 @@ class LiveStreamEventAdminTests(TestCase):
         self.assertEqual(LiveStreamEvent.objects.count(), 1)
 
     @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_add_event_with_expired_authorisation_is_graceful(
+        self, mock_youtube_prop
+    ):
+        mock_youtube_prop.side_effect = RefreshError(
+            "invalid_grant: Token has been expired or revoked."
+        )
+
+        season = factories.SeasonFactory.create(
+            timezone="UTC",
+            live_stream=True,
+            live_stream_client_id="client-id",
+            live_stream_client_secret="client-secret",
+        )
+        with self.login(self.superuser):
+            self.post(
+                "admin:fixja:competition:season:livestreamevent:add",
+                season.competition_id,
+                season.pk,
+                data={
+                    "title": "Opening Ceremony",
+                    "description": "",
+                    "start_0_year": "2025",
+                    "start_0_month": "5",
+                    "start_0_day": "1",
+                    "start_1": "19",
+                    "start_2": "0",
+                    "stop_0_year": "2025",
+                    "stop_0_month": "5",
+                    "stop_0_day": "1",
+                    "stop_1": "20",
+                    "stop_2": "30",
+                },
+            )
+            self.response_302()
+
+        self.assertEqual(season.live_stream_events.count(), 0)
+        self.assertIn(
+            "YouTube authorisation for this season has expired or been revoked.",
+            " ".join(
+                str(message)
+                for message in get_messages(self.last_response.wsgi_request)
+            ),
+        )
+
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_delete_event_with_expired_authorisation_is_blocked(
+        self, mock_youtube_prop
+    ):
+        mock_youtube_prop.side_effect = RefreshError(
+            "invalid_grant: Token has been expired or revoked."
+        )
+
+        event = factories.LiveStreamEventFactory.create(
+            season__live_stream=True,
+            season__live_stream_client_id="client-id",
+            season__live_stream_client_secret="client-secret",
+            external_identifier="adhoc123",
+        )
+        with self.login(self.superuser):
+            self.post(
+                "admin:fixja:competition:season:livestreamevent:delete",
+                event.season.competition_id,
+                event.season_id,
+                event.pk,
+            )
+            self.response_302()
+
+        # Destruction on the platform cannot be confirmed, the record stays.
+        self.assertEqual(LiveStreamEvent.objects.count(), 1)
+
+    @mock.patch(
         "tournamentcontrol.competition.signals.live_streams.delete_youtube_broadcast"
     )
     def test_model_delete_queues_platform_cleanup(self, mock_broadcast_task):
@@ -914,6 +993,33 @@ class LiveStreamKeyAdminTests(TestCase):
         self.assertEqual(stream_key.title, "Roaming Camera")
         self.assertEqual(stream_key.pk, "stream456")
         self.assertEqual(stream_key.stream_key, "abcd-1234")
+
+    @mock.patch(
+        "tournamentcontrol.competition.models.Season.youtube",
+        new_callable=mock.PropertyMock,
+    )
+    def test_add_stream_key_with_expired_authorisation_is_graceful(
+        self, mock_youtube_prop
+    ):
+        mock_youtube_prop.side_effect = RefreshError(
+            "invalid_grant: Token has been expired or revoked."
+        )
+
+        season = factories.SeasonFactory.create(
+            live_stream=True,
+            live_stream_client_id="client-id",
+            live_stream_client_secret="client-secret",
+        )
+        with self.login(self.superuser):
+            self.post(
+                "admin:fixja:competition:season:livestreamkey:add",
+                season.competition_id,
+                season.pk,
+                data={"title": "Roaming Camera"},
+            )
+            self.response_302()
+
+        self.assertEqual(season.live_stream_keys.count(), 0)
 
     @mock.patch(
         "tournamentcontrol.competition.models.Season.youtube",


### PR DESCRIPTION
## Summary

Fixes the 500 on `/live-stream-event/add/` when the season's YouTube authorisation has lapsed ([FIT-TOURNAMENTS-4C](https://touch-technology.sentry.io/issues/FIT-TOURNAMENTS-4C) / [FIT-TOURNAMENTS-25](https://touch-technology.sentry.io/issues/FIT-TOURNAMENTS-25)).

When the stored OAuth2 refresh token is expired or revoked, the Google client raises `RefreshError` (`invalid_grant`) as soon as the platform is touched — in this case inside `edit_livestreamevent`'s pre-save broadcast insert, which only caught `HttpError`, so the exception escaped as a 500 page.

`RefreshError` is now caught alongside `HttpError` at every platform interaction in the adhoc live stream feature:

- **Event creation** — save is aborted with "YouTube authorisation for this season has expired or been revoked. Re-authorise from the YouTube button on the seasons list and try again."
- **Stream key creation/update** — same message, save aborted.
- **Both guarded delete flows** — the record is retained, consistent with destruction not being confirmable without authorisation.

The match-streaming code paths (`edit_ground`, `stream_control`, REST `transition`) have the same latent gap; deliberately out of scope here and tracked in #310.

## Test plan

- [x] Three new tests mock `Season.youtube` to raise `RefreshError` and assert: event add redirects with the guidance message and creates nothing; key add creates nothing; event delete retains the record.
- [x] Full `test_live_stream_event` module (59) plus `test_competition_admin` and `test_match_livestream` regression modules green locally.
- [x] E2E fixture flake fixed along the way (factory could draw a start year outside the widget's year-select range).

Fixes FIT-TOURNAMENTS-4C
Fixes FIT-TOURNAMENTS-25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1Hyp8Ui51TB1Fs6c4iy4q