### PR TITLE
Copy video link buttons on the live stream events tab

### DIFF
--- a/tests/e2e/test_live_stream_event.py
+++ b/tests/e2e/test_live_stream_event.py
@@ -53,6 +53,40 @@ class TestLiveStreamEventForm:
             f"{season.competition.pk}/seasons/{season.pk}/"
         )
 
+    def test_copy_video_link_button(
+        self, authenticated_page: Page, live_server, live_stream_season, screenshot_dir
+    ):
+        """
+        The events tab offers a per-row button that copies the youtu.be
+        link for the broadcast to the clipboard, without submitting the
+        surrounding season form.
+        """
+        page = authenticated_page
+        season = live_stream_season["season"]
+        event = live_stream_season["event"]
+
+        page.context.grant_permissions(["clipboard-read", "clipboard-write"])
+        page.goto(self._season_url(live_server, season))
+        page.locator('a[href="#live_stream_events-tab"]').click()
+
+        button = page.locator(".js-copy-video-link")
+        expect(button).to_be_visible()
+        button.click()
+
+        # The youtu.be form of the link is now on the clipboard.
+        clipboard = page.evaluate("navigator.clipboard.readText()")
+        assert clipboard == f"https://youtu.be/{event.pk}"
+
+        # Visual feedback, and the click must not have navigated away by
+        # submitting the season form.
+        expect(button.locator("i")).to_have_class("fa fa-check")
+        expect(page.locator("#live_stream_events-tab")).to_be_visible()
+
+        page.screenshot(
+            path=str(screenshot_dir / "live_stream_event_copy_link.png"),
+            full_page=True,
+        )
+
     def test_season_edit_shows_live_stream_tabs(
         self, authenticated_page: Page, live_server, live_stream_season, screenshot_dir
     ):

--- a/tournamentcontrol/competition/models.py
+++ b/tournamentcontrol/competition/models.py
@@ -2890,6 +2890,11 @@ class LiveStreamEvent(AdminUrlMixin, models.Model):
         # No per-object permissions view is routed for this model.
         return ["add", "edit", "delete"]
 
+    @property
+    def video_url(self):
+        """Shareable link to the broadcast on the YouTube platform."""
+        return f"https://youtu.be/{self.external_identifier}"
+
     def clean(self):
         errors = {}
         if self.start and self.stop and self.stop <= self.start:

--- a/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/livestreamevent/list.inc.html
+++ b/tournamentcontrol/competition/templates/tournamentcontrol/competition/admin/livestreamevent/list.inc.html
@@ -28,4 +28,46 @@
 	</td>
 {% endblock %}
 
+{% block row-buttons %}
+	{% if obj.live_stream %}
+		{# The rows render inside the season edit <form>, so the button #}
+		{# must never act as a submit. #}
+		<button type="button"
+				class="btn btn-default btn-sm js-copy-video-link"
+				data-video-url="{{ obj.video_url }}"
+				title="{% trans "Copy video link" %}">
+			<i class="fa fa-clipboard"></i>
+			<span class="hidden-sm hidden-xs">&nbsp;{% trans "Copy video link" %}</span>
+		</button>
+	{% endif %}
+	{{ block.super }}
+{% endblock %}
+
 {% block empty-row-colspan %}5{% endblock %}
+
+{% block pagination %}
+	{{ block.super }}
+	<style>
+		.js-copy-video-link {
+			vertical-align: middle;
+		}
+		.js-copy-video-link + .dropdown {
+			display: inline-block;
+			vertical-align: middle;
+			margin-left: 4px;
+		}
+	</style>
+	<script>
+		document.addEventListener("click", function (e) {
+			var button = e.target.closest(".js-copy-video-link");
+			if (!button) return;
+			navigator.clipboard.writeText(button.dataset.videoUrl).then(function () {
+				var icon = button.querySelector("i");
+				icon.className = "fa fa-check";
+				setTimeout(function () {
+					icon.className = "fa fa-clipboard";
+				}, 2000);
+			});
+		});
+	</script>
+{% endblock %}

--- a/tournamentcontrol/competition/tests/test_live_stream_event.py
+++ b/tournamentcontrol/competition/tests/test_live_stream_event.py
@@ -100,6 +100,12 @@ class LiveStreamEventModelTests(TestCase):
         event = factories.LiveStreamEventFactory.create()
         self.assertCountEqual(event.season.live_stream_events.all(), [event])
 
+    def test_video_url(self):
+        event = factories.LiveStreamEventFactory.create(
+            external_identifier="adhoc123"
+        )
+        self.assertEqual(event.video_url, "https://youtu.be/adhoc123")
+
 
 class LiveStreamKeyModelTests(TestCase):
     def test_str_without_generated_key_is_title(self):
@@ -559,6 +565,36 @@ class LiveStreamEventAdminTests(TestCase):
             )
             self.assertResponseContains("Opening Ceremony", html=False)
             self.assertResponseContains("live_stream_events-tab", html=False)
+
+    def test_season_edit_offers_copy_video_link(self):
+        event = factories.LiveStreamEventFactory.create(
+            season__live_stream=True, external_identifier="adhoc123"
+        )
+        with self.login(self.superuser):
+            self.assertGoodView(
+                "admin:fixja:competition:season:edit",
+                event.season.competition_id,
+                event.season_id,
+            )
+            self.assertResponseContains(
+                'data-video-url="https://youtu.be/adhoc123"', html=False
+            )
+
+    def test_season_edit_hides_copy_video_link_for_removed_broadcast(self):
+        event = factories.LiveStreamEventFactory.create(
+            season__live_stream=True,
+            external_identifier="adhoc123",
+            live_stream=False,
+        )
+        with self.login(self.superuser):
+            self.assertGoodView(
+                "admin:fixja:competition:season:edit",
+                event.season.competition_id,
+                event.season_id,
+            )
+            self.assertResponseNotContains(
+                'data-video-url="https://youtu.be/adhoc123"', html=False
+            )
 
     def test_season_edit_hides_events_tab_when_not_live_streamed(self):
         season = factories.SeasonFactory.create(live_stream=False)


### PR DESCRIPTION
## Summary

Makes it easy to copy video links from the admin: each row on the season's "Live stream events" tab gains a **Copy video link** button that puts the shareable `https://youtu.be/<id>` form on the clipboard, with a brief check-mark feedback state.

- `LiveStreamEvent.video_url` property supplies the link (the broadcast id is the primary key, so this is purely presentational — no schema change).
- The button only renders while the broadcast still exists (`live_stream` enabled); a removed broadcast has no video to link to.
- Explicitly `type="button"` — the rows render inside the season edit `<form>`, so a default submit button would save the season.

## Test plan

- [x] Unit: `video_url` property; button present (with the `youtu.be` URL) on the season edit page for a live event and absent for a removed broadcast.
- [x] E2E: clicks the button with clipboard permissions granted, asserts the clipboard contains the `youtu.be` link, the check-mark feedback appears, and the page did not navigate (no form submit) — screenshot captured into the `e2e-test-screenshots` artifact.
- [x] Full unit module (62) and e2e module (4) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1Hyp8Ui51TB1Fs6c4iy4q

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1Hyp8Ui51TB1Fs6c4iy4q)_