### PR TITLE
Do not attribute a ladder summary to a pool from another stage

### DIFF
--- a/tournamentcontrol/competition/migrations/0062_fix_cross_stage_ladder_summary_pool.py
+++ b/tournamentcontrol/competition/migrations/0062_fix_cross_stage_ladder_summary_pool.py
@@ -1,0 +1,32 @@
+# Data migration to detach ladder summaries from pools in a different stage.
+
+from django.db import migrations
+from django.db.models import F
+
+
+def clear_cross_stage_stage_group(apps, schema_editor):
+    """
+    A ``LadderSummary`` used to inherit the ``stage_group`` of the team rather
+    than of the stage the summary belongs to. Where a team played in a later
+    stage which does not have pools, the summary for that stage was attributed
+    to the pool the team was drawn into for an earlier stage, and was therefore
+    reported as part of that pool's ladder as well as its own stage.
+    """
+    LadderSummary = apps.get_model("competition", "LadderSummary")
+    LadderSummary.objects.filter(stage_group__isnull=False).exclude(
+        stage_group__stage=F("stage")
+    ).update(stage_group=None)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("competition", "0061_live_stream_event"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            clear_cross_stage_stage_group,
+            reverse_code=migrations.RunPython.noop,
+            elidable=True,
+        ),
+    ]

--- a/tournamentcontrol/competition/signals/ladders.py
+++ b/tournamentcontrol/competition/signals/ladders.py
@@ -184,8 +184,22 @@ def team_ladder_entry_aggregation(sender, instance, created=None, *args, **kwarg
     aggregate.update({"difference": difference})
     aggregate.update({"percentage": percentage})
 
+    # A team keeps a reference to the pool it was drawn into, which belongs to
+    # a single stage. When a later stage reuses some of those teams -- for
+    # example a combined age group where the second stage is a round robin of
+    # the teams from one grade -- the pool must not be carried onto the summary
+    # or it will be reported as part of the earlier stage's pool ladder.
+    stage_group = instance.team.stage_group
+    if stage_group is not None and stage_group.stage_id != instance.match.stage_id:
+        logger.debug(
+            "%r belongs to %r from another stage, not attributing summary to it.",
+            instance.team,
+            stage_group,
+        )
+        stage_group = None
+
     instance.team.ladder_summary.create(
         stage=instance.match.stage,
-        stage_group=instance.team.stage_group,
+        stage_group=stage_group,
         **aggregate,
     )

--- a/tournamentcontrol/competition/tests/test_signals.py
+++ b/tournamentcontrol/competition/tests/test_signals.py
@@ -1,17 +1,7 @@
-import importlib
-
-from django.apps import apps
 from django.test import TestCase
 
 from tournamentcontrol.competition.models import LadderEntry, LadderSummary
 from tournamentcontrol.competition.tests import factories
-
-# The repair migration is named with a numeric prefix so it cannot be imported
-# with the ``from ... import ...`` syntax.
-repair = importlib.import_module(
-    "tournamentcontrol.competition.migrations"
-    ".0062_fix_cross_stage_ladder_summary_pool"
-)
 
 
 class SignalHandlerTests(TestCase):
@@ -199,25 +189,4 @@ class CombinedAgeGradeLadderTests(TestCase):
         self.assertEqual(
             [self.m55_a1, self.m55_a2, self.m55_b1],
             sorted((s.team for s in ladders[self.m55_stage]), key=lambda t: t.pk),
-        )
-
-    def test_repair_migration_detaches_cross_stage_pool(self):
-        # Reproduce the data as it was written before the signal was fixed;
-        # the summary took the pool from the team, not from its own stage.
-        for summary in LadderSummary.objects.filter(stage=self.m55_stage):
-            summary.stage_group = summary.team.stage_group
-            summary.save(update_fields=["stage_group"])
-
-        self.assertEqual(6, self.pool_a.ladder_summary.count())
-        self.assertEqual(4, self.pool_b.ladder_summary.count())
-
-        repair.clear_cross_stage_stage_group(apps, None)
-
-        self.assertEqual(4, self.pool_a.ladder_summary.count())
-        self.assertEqual(3, self.pool_b.ladder_summary.count())
-        self.assertQuerySetEqual(
-            LadderSummary.objects.filter(stage=self.m55_stage).values_list(
-                "stage_group", flat=True
-            ),
-            [None, None, None],
         )

--- a/tournamentcontrol/competition/tests/test_signals.py
+++ b/tournamentcontrol/competition/tests/test_signals.py
@@ -1,7 +1,17 @@
+import importlib
+
+from django.apps import apps
 from django.test import TestCase
 
 from tournamentcontrol.competition.models import LadderEntry, LadderSummary
 from tournamentcontrol.competition.tests import factories
+
+# The repair migration is named with a numeric prefix so it cannot be imported
+# with the ``from ... import ...`` syntax.
+repair = importlib.import_module(
+    "tournamentcontrol.competition.migrations"
+    ".0062_fix_cross_stage_ladder_summary_pool"
+)
 
 
 class SignalHandlerTests(TestCase):
@@ -55,4 +65,159 @@ class SignalHandlerTests(TestCase):
                 "score_against",
                 "difference",
             ),
+        )
+
+
+class CombinedAgeGradeLadderTests(TestCase):
+    """
+    Model the "Mens 50/55" structure used at Euros 2026.
+
+    Two age grades were combined into a single division; the first stage is a
+    pool stage mixing M50 and M55 teams, and the second stage is a M55-only
+    round robin (no pools) which picks up the M55 fixtures that were not
+    played in the pool stage.
+
+    Teams keep a ``stage_group`` pointing at their pool from the first stage,
+    so the ladder summaries built for the second stage must not be attributed
+    to that pool.
+    """
+
+    def setUp(self):
+        self.division = factories.DivisionFactory.create(title="Mens 50/55")
+
+        self.pool_stage = factories.StageFactory.create(
+            division=self.division, title="Pool Play", order=1
+        )
+        self.pool_a = factories.StageGroupFactory.create(
+            stage=self.pool_stage, title="Pool A", order=1
+        )
+        self.pool_b = factories.StageGroupFactory.create(
+            stage=self.pool_stage, title="Pool B", order=2
+        )
+
+        self.m55_stage = factories.StageFactory.create(
+            division=self.division, title="Mens 55", order=2
+        )
+
+        # Pool A has two M50 teams and two M55 teams.
+        self.m50_a1, self.m50_a2 = [
+            factories.TeamFactory.create(
+                division=self.division, stage_group=self.pool_a
+            )
+            for _ in range(2)
+        ]
+        self.m55_a1, self.m55_a2 = [
+            factories.TeamFactory.create(
+                division=self.division, stage_group=self.pool_a
+            )
+            for _ in range(2)
+        ]
+
+        # Pool B has two M50 teams and one M55 team.
+        self.m50_b1, self.m50_b2 = [
+            factories.TeamFactory.create(
+                division=self.division, stage_group=self.pool_b
+            )
+            for _ in range(2)
+        ]
+        self.m55_b1 = factories.TeamFactory.create(
+            division=self.division, stage_group=self.pool_b
+        )
+
+        # Round robin in each pool, except the M55 v M55 fixture in Pool A
+        # which is deferred to the second stage so it is not duplicated.
+        pool_a_teams = [self.m50_a1, self.m50_a2, self.m55_a1, self.m55_a2]
+        for index, home in enumerate(pool_a_teams):
+            for away in pool_a_teams[index + 1 :]:
+                if {home, away} == {self.m55_a1, self.m55_a2}:
+                    continue
+                factories.MatchFactory.create(
+                    stage=self.pool_stage,
+                    stage_group=self.pool_a,
+                    home_team=home,
+                    home_team_score=5,
+                    away_team=away,
+                    away_team_score=3,
+                )
+
+        pool_b_teams = [self.m50_b1, self.m50_b2, self.m55_b1]
+        for index, home in enumerate(pool_b_teams):
+            for away in pool_b_teams[index + 1 :]:
+                factories.MatchFactory.create(
+                    stage=self.pool_stage,
+                    stage_group=self.pool_b,
+                    home_team=home,
+                    home_team_score=4,
+                    away_team=away,
+                    away_team_score=2,
+                )
+
+        # Second stage; a round robin of the three M55 teams, including the
+        # fixture uprooted from Pool A.
+        m55_teams = [self.m55_a1, self.m55_a2, self.m55_b1]
+        for index, home in enumerate(m55_teams):
+            for away in m55_teams[index + 1 :]:
+                factories.MatchFactory.create(
+                    stage=self.m55_stage,
+                    home_team=home,
+                    home_team_score=6,
+                    away_team=away,
+                    away_team_score=1,
+                )
+
+    def test_second_stage_summary_has_no_stage_group(self):
+        self.assertQuerySetEqual(
+            LadderSummary.objects.filter(stage=self.m55_stage).values_list(
+                "stage_group", flat=True
+            ),
+            [None, None, None],
+        )
+
+    def test_pool_ladder_only_contains_own_stage(self):
+        for pool, expected in ((self.pool_a, 4), (self.pool_b, 3)):
+            with self.subTest(pool=pool.title):
+                summary = pool.ladder_summary.all()
+                self.assertEqual(expected, summary.count())
+                self.assertQuerySetEqual(
+                    summary.values_list("stage", flat=True),
+                    [self.pool_stage.pk] * expected,
+                )
+
+    def test_division_ladders_do_not_duplicate_teams(self):
+        ladders = self.division.ladders()
+
+        pools = ladders[self.pool_stage]
+        self.assertEqual(
+            [self.m50_a1, self.m50_a2, self.m55_a1, self.m55_a2],
+            sorted((s.team for s in pools[self.pool_a]), key=lambda t: t.pk),
+        )
+        self.assertEqual(
+            [self.m50_b1, self.m50_b2, self.m55_b1],
+            sorted((s.team for s in pools[self.pool_b]), key=lambda t: t.pk),
+        )
+
+        self.assertEqual(
+            [self.m55_a1, self.m55_a2, self.m55_b1],
+            sorted((s.team for s in ladders[self.m55_stage]), key=lambda t: t.pk),
+        )
+
+    def test_repair_migration_detaches_cross_stage_pool(self):
+        # Reproduce the data as it was written before the signal was fixed;
+        # the summary took the pool from the team, not from its own stage.
+        for summary in LadderSummary.objects.filter(stage=self.m55_stage):
+            summary.stage_group = summary.team.stage_group
+            summary.save(update_fields=["stage_group"])
+
+        self.assertEqual(6, self.pool_a.ladder_summary.count())
+        self.assertEqual(4, self.pool_b.ladder_summary.count())
+
+        repair.clear_cross_stage_stage_group(apps, None)
+
+        self.assertEqual(4, self.pool_a.ladder_summary.count())
+        self.assertEqual(3, self.pool_b.ladder_summary.count())
+        self.assertQuerySetEqual(
+            LadderSummary.objects.filter(stage=self.m55_stage).values_list(
+                "stage_group", flat=True
+            ),
+            [None, None, None],
         )


### PR DESCRIPTION
## Problem

Reported against https://www.internationaltouch.org/events/euros/2026/mens-5055/ — the ladder for the second stage was also appearing inside the first stage's pool ladders.

That event combines two age grades (M50 and M55) into one division. The first stage is a pool stage mixing both grades (Pool A with two M55 teams, Pool B with one), and the second stage is an M55-only round robin with no pools, which picks up the M55 v M55 fixture that was deliberately not played in Pool A so it wasn't duplicated.

## Cause

This is a library problem, not a site template one — the internationaltouch templates just render whatever `Division.ladders()` hands them.

`Team.stage_group` is a single FK: it records the pool a team was drawn into, and that pool belongs to exactly one stage. `team_ladder_entry_aggregation` built the `LadderSummary` with `stage_group=instance.team.stage_group`, taking the pool from the team rather than from the stage the summary is for. So a summary for the second stage was written with the team's *first* stage pool.

`LadderSummary.stage_group` has `related_name="ladder_summary"`, so those rows were then returned by `pool.ladder_summary.all()` for a pool in the earlier stage — which is what `StageGroup.ladders()`, `Division.ladders()` and `Team.ladders()` all iterate. The summary showed up twice: once under its own stage, once under the earlier pool.

It only surfaces in this shape of draw because a stage with `keep_ladder=False` (the usual final series or knockout) never gets a summary at all, so the more common "pools then finals" structure is unaffected.

## Changes

- `signals/ladders.py` — only carry the team's pool onto the summary when that pool belongs to the match's stage, otherwise leave it null. Deliberately kept as a check on the team's pool rather than switching to `match.stage_group`, so a match not assigned to a pool within a pooled stage still lands on the right pool ladder.
- `migrations/0062_fix_cross_stage_ladder_summary_pool.py` — data migration detaching summaries already written with a pool from another stage, so existing sites are corrected without needing every match re-saved.
- `tests/test_signals.py` — new `CombinedAgeGradeLadderTests` building the Euros M50/55 structure (two mixed pools, one M55 round robin second stage with the uprooted fixture). Every match is created with scores, so the summaries under test are produced by the real signal chain rather than being hand-built. Three assertions, one per layer the bug crosses: the second-stage summaries carry no pool, `pool.ladder_summary` only returns rows from its own stage, and `Division.ladders()` lists each team exactly once per pool.

The data migration itself is not covered by a test, consistent with the rest of the project. Reaching the repair function would have meant importing the migration module through `importlib` (its name starts with a digit), and passing the live app registry rather than the historical one would have exercised the query rather than the migration as it actually runs.

## Testing

Written test-first; all three assertions failed against `main` — the second-stage summaries came back with pool ids `[5, 5, 6]` instead of `[None, None, None]`, and Pool A's ladder had 6 rows instead of 4.

Full `tournamentcontrol.competition` suite on Django 5.2 / Python 3.13: 406 tests, `OK (skipped=4, expected failures=4)`.