### PR TITLE
Date the first game of each day on the team schedule

### DIFF
--- a/tournamentcontrol/competition/templates/tournamentcontrol/competition/team.html
+++ b/tournamentcontrol/competition/templates/tournamentcontrol/competition/team.html
@@ -26,6 +26,7 @@
 	<table class="team draw">
 		<thead>
 			<tr>
+				<th>{% trans "Date" %}</th>
 				<th>{% trans "Time" %}</th>
 				<th>{% trans "Venue" %}</th>
 				<th>{% trans "Opponent" %}</th>
@@ -34,15 +35,15 @@
 			</tr>
 		</thead>
 		<tbody>
-			{# The date heads each group rather than repeating on every row, so #}
-			{# the number of games in a day can be seen at a glance. #}
 			{% for date, matches in team.matches_by_date.items %}
-			<tr class="day">
-				<th colspan="5">{{ date|default:tba }}</th>
-			</tr>
 			{% for match in matches %}
 				{% with home=match.get_home_team away=match.get_away_team %}
 					<tr class="{% if forloop.first %}first {% endif %}{% cycle "odd" "even" %}{% if forloop.last %} last{% endif %}">
+						{# Matches arrive grouped by day, and `ifchanged` binds its state to #}
+						{# the innermost loop, so the date is written against the first game #}
+						{# of a day and left out of the rest -- which is what makes the #}
+						{# number of games played on a day legible on a narrow screen. #}
+						<td class="date">{% ifchanged date %}{{ date|default:tba }}{% endifchanged %}</td>
 						<td class="time">{{ match.datetime|time|default:tba }}</td>
 						<td class="venue">{{ match.play_at.title|default:tba }}</td>
 						{% with match|opponent:team as opponent %}

--- a/tournamentcontrol/competition/templates/tournamentcontrol/competition/team.html
+++ b/tournamentcontrol/competition/templates/tournamentcontrol/competition/team.html
@@ -26,7 +26,6 @@
 	<table class="team draw">
 		<thead>
 			<tr>
-				<th>{% trans "Date" %}</th>
 				<th>{% trans "Time" %}</th>
 				<th>{% trans "Venue" %}</th>
 				<th>{% trans "Opponent" %}</th>
@@ -35,11 +34,15 @@
 			</tr>
 		</thead>
 		<tbody>
+			{# The date heads each group rather than repeating on every row, so #}
+			{# the number of games in a day can be seen at a glance. #}
 			{% for date, matches in team.matches_by_date.items %}
+			<tr class="day">
+				<th colspan="5">{{ date|default:tba }}</th>
+			</tr>
 			{% for match in matches %}
 				{% with home=match.get_home_team away=match.get_away_team %}
 					<tr class="{% if forloop.first %}first {% endif %}{% cycle "odd" "even" %}{% if forloop.last %} last{% endif %}">
-						<td class="date">{{ date }}</td>
 						<td class="time">{{ match.datetime|time|default:tba }}</td>
 						<td class="venue">{{ match.play_at.title|default:tba }}</td>
 						{% with match|opponent:team as opponent %}

--- a/tournamentcontrol/competition/tests/test_competition_site.py
+++ b/tournamentcontrol/competition/tests/test_competition_site.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 from django.test import override_settings
+from django.utils.formats import date_format
 from freezegun import freeze_time
 from icalendar import Calendar
 from test_plus import TestCase
@@ -141,6 +142,23 @@ class GoodViewTests(TestCase):
             pool.slug,
         )
 
+    def test_team(self):
+        stage = factories.StageFactory.create()
+        team = factories.TeamFactory.create(division=stage.division)
+        factories.MatchFactory.create_batch(
+            stage=stage,
+            home_team=team,
+            size=5,
+            datetime=datetime(2022, 7, 2, 9, tzinfo=ZoneInfo("UTC")),
+        )
+        self.assertGoodView(
+            "competition:team",
+            stage.division.season.competition.slug,
+            stage.division.season.slug,
+            stage.division.slug,
+            team.slug,
+        )
+
     def test_match(self):
         match = factories.MatchFactory.create()
         self.assertGoodView(
@@ -270,6 +288,34 @@ class FrontEndTests(TestCase):
             self.assertResponseContains(
                 '<a href="{0}">{1}</a>'.format(href, team.title)
             )
+
+    def test_team_schedule_groups_matches_by_date(self):
+        """
+        Each day of a team's schedule is headed by its date once instead
+        of the date repeating against every match, so how many games are
+        played on a day can be seen at a glance.
+        """
+        stage = factories.StageFactory.create()
+        team = factories.TeamFactory.create(division=stage.division)
+        days = (
+            datetime(2022, 7, 2, 9, tzinfo=ZoneInfo("UTC")),
+            datetime(2022, 7, 3, 9, tzinfo=ZoneInfo("UTC")),
+        )
+        for size, when in enumerate(days, start=1):
+            factories.MatchFactory.create_batch(
+                stage=stage, home_team=team, size=size, datetime=when
+            )
+        self.assertGoodView(
+            "competition:team",
+            stage.division.season.competition.slug,
+            stage.division.season.slug,
+            stage.division.slug,
+            team.slug,
+        )
+        content = self.last_response.content.decode()
+        self.assertEqual(len(days), content.count('<tr class="day">'))
+        for when in days:
+            self.assertEqual(1, content.count(date_format(when.date())))
 
     def test_team_calendar(self):
         team = factories.TeamFactory.create()

--- a/tournamentcontrol/competition/tests/test_competition_site.py
+++ b/tournamentcontrol/competition/tests/test_competition_site.py
@@ -289,11 +289,11 @@ class FrontEndTests(TestCase):
                 '<a href="{0}">{1}</a>'.format(href, team.title)
             )
 
-    def test_team_schedule_groups_matches_by_date(self):
+    def test_team_schedule_dates_the_first_game_of_each_day(self):
         """
-        Each day of a team's schedule is headed by its date once instead
-        of the date repeating against every match, so how many games are
-        played on a day can be seen at a glance.
+        The date is written against the first game of a day and left out
+        of the rest, instead of repeating on every match, so how many
+        games are played on a day can be seen at a glance.
         """
         stage = factories.StageFactory.create()
         team = factories.TeamFactory.create(division=stage.division)
@@ -313,7 +313,9 @@ class FrontEndTests(TestCase):
             team.slug,
         )
         content = self.last_response.content.decode()
-        self.assertEqual(len(days), content.count('<tr class="day">'))
+        # Three matches, so three date cells, but only two carry a date.
+        self.assertEqual(3, content.count('<td class="date">'))
+        self.assertEqual(1, content.count('<td class="date"></td>'))
         for when in days:
             self.assertEqual(1, content.count(date_format(when.date())))
 

--- a/tournamentcontrol/competition/tests/test_competition_site.py
+++ b/tournamentcontrol/competition/tests/test_competition_site.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 from django.test import override_settings
-from django.utils.formats import date_format
 from freezegun import freeze_time
 from icalendar import Calendar
 from test_plus import TestCase
@@ -297,13 +296,20 @@ class FrontEndTests(TestCase):
         """
         stage = factories.StageFactory.create()
         team = factories.TeamFactory.create(division=stage.division)
-        days = (
-            datetime(2022, 7, 2, 9, tzinfo=ZoneInfo("UTC")),
-            datetime(2022, 7, 3, 9, tzinfo=ZoneInfo("UTC")),
+        # One game on the 2nd, two on the 3rd.
+        fixtures = (
+            ("Ireland", datetime(2022, 7, 2, 9, tzinfo=ZoneInfo("UTC"))),
+            ("Wales", datetime(2022, 7, 3, 9, tzinfo=ZoneInfo("UTC"))),
+            ("England", datetime(2022, 7, 3, 9, tzinfo=ZoneInfo("UTC"))),
         )
-        for size, when in enumerate(days, start=1):
-            factories.MatchFactory.create_batch(
-                stage=stage, home_team=team, size=size, datetime=when
+        for title, when in fixtures:
+            factories.MatchFactory.create(
+                stage=stage,
+                home_team=team,
+                away_team=factories.TeamFactory.create(
+                    division=stage.division, title=title, club__title=title
+                ),
+                datetime=when,
             )
         self.assertGoodView(
             "competition:team",
@@ -312,12 +318,65 @@ class FrontEndTests(TestCase):
             stage.division.slug,
             team.slug,
         )
+
+        def opponent(title):
+            href = self.reverse(
+                "competition:team",
+                stage.division.season.competition.slug,
+                stage.division.season.slug,
+                stage.division.slug,
+                title.lower(),
+            )
+            return '<td class="team {0}"><a href="{1}">{2}</a></td>'.format(
+                title.lower(), href, title
+            )
+
         content = self.last_response.content.decode()
-        # Three matches, so three date cells, but only two carry a date.
-        self.assertEqual(3, content.count('<td class="date">'))
-        self.assertEqual(1, content.count('<td class="date"></td>'))
-        for when in days:
-            self.assertEqual(1, content.count(date_format(when.date())))
+        self.assertHTMLEqual(
+            content.split('<table class="team draw">')[1].split("</table>")[0],
+            """
+            <thead>
+                <tr>
+                    <th>Date</th>
+                    <th>Time</th>
+                    <th>Venue</th>
+                    <th>Opponent</th>
+                    <th>Result</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr class="first odd last">
+                    <td class="date">July 2, 2022</td>
+                    <td class="time">9 a.m.</td>
+                    <td class="venue">TBA</td>
+                    {ireland}
+                    <td>-</td>
+                    <td></td>
+                </tr>
+                <tr class="first even">
+                    <td class="date">July 3, 2022</td>
+                    <td class="time">9 a.m.</td>
+                    <td class="venue">TBA</td>
+                    {wales}
+                    <td>-</td>
+                    <td></td>
+                </tr>
+                <tr class="odd last">
+                    <td class="date"></td>
+                    <td class="time">9 a.m.</td>
+                    <td class="venue">TBA</td>
+                    {england}
+                    <td>-</td>
+                    <td></td>
+                </tr>
+            </tbody>
+            """.format(
+                ireland=opponent("Ireland"),
+                wales=opponent("Wales"),
+                england=opponent("England"),
+            ),
+        )
 
     def test_team_calendar(self):
         team = factories.TeamFactory.create()


### PR DESCRIPTION
The team schedule is read on a phone more often than a desktop. Matches already come back grouped by date via `Team.matches_by_date`, but the date was rendered into a column on every row — so a day with four games looked no different to four days with one.

Keep the single table and wrap the date cell in `{% ifchanged %}`. `ifchanged` binds its state to the innermost loop, so with matches already grouped by day the date lands on the first game of a day and the rest of that day's rows stay blank.

```
Date        Time    Venue    Opponent   Result
22/7/2026    9:25   Field 1  Ireland    Won 8-7    Detail
            12:10   Field 3  Wales      Won 11-7   Detail
            16:45   Field 1  England    Lost 3-15  Detail
23/7/2026   12:10   Field 2  France     Won 7-5    Detail
```

### Changes

`tournamentcontrol/competition/templates/tournamentcontrol/competition/team.html`

- `<td class="date">{% ifchanged date %}{{ date|default:tba }}{% endifchanged %}</td>` in place of the unconditional cell.
- The cell falls back to TBA where the group has no date, rather than rendering the literal `None` it used to.

Markup only — no CSS ships for this table, and the column set is unchanged, so downstream themes keep working untouched.

An earlier revision of this PR grouped the rows under a full-width `<tr class="day">` heading instead. That was reverted: it broke the column grid, and a reusable template cannot assume the styling that would make such a row look like anything.

### Testing

`tournamentcontrol/competition/tests/test_competition_site.py`

- `GoodViewTests.test_team` — the team view had no render coverage at all; this adds it.
- `FrontEndTests.test_team_schedule_dates_the_first_game_of_each_day` — one match on one day and two on the next; asserts three date cells with one left empty, and each date appearing exactly once.

Run against Django 6.0 / Python 3.13: `tournamentcontrol.competition` — 408 passed (4 skipped, 4 expected failures). `isort` and `ruff check` clean; `black` reports no diff in the added hunks (it wants to reformat pre-existing code elsewhere in the file, left alone).

`tox-docker` could not start the postgres container in this environment (docker 29 no longer exposes `NetworkSettings.Gateway`, which the plugin reads), so the tox env was provisioned with `--notest` and its command run against a hand-started `postgres:14-alpine`.

### Downstream

`goodtune/internationaltouch#1093` applies the same treatment to that site's override of this template.
